### PR TITLE
Hotfix :: JWT 검증 로직 & CustomException & BaseResponse

### DIFF
--- a/src/main/kotlin/seugi/server/domain/member/adapter/out/MemberAdapter.kt
+++ b/src/main/kotlin/seugi/server/domain/member/adapter/out/MemberAdapter.kt
@@ -4,9 +4,11 @@ import org.springframework.stereotype.Component
 import seugi.server.domain.member.adapter.out.mapper.MemberMapper
 import seugi.server.domain.member.adapter.out.repository.MemberRepository
 import seugi.server.domain.member.application.model.Member
+import seugi.server.domain.member.exception.MemberErrorCode
 import seugi.server.domain.member.port.out.ExistMemberPort
 import seugi.server.domain.member.port.out.LoadMemberPort
 import seugi.server.domain.member.port.out.SaveMemberPort
+import seugi.server.global.exception.CustomException
 
 @Component
 class MemberAdapter (
@@ -22,13 +24,19 @@ class MemberAdapter (
 
     override fun loadMemberWithId(id: Long): Member {
         return memberMapper.toDomain(
-            memberRepository.findById(id).get()
+            memberRepository.findById(id)
+                .orElseThrow {
+                    CustomException(MemberErrorCode.MEMBER_NOT_FOUND)
+                }
         )
     }
 
     override fun loadMemberWithEmail(email: String): Member {
         return memberMapper.toDomain(
-            memberRepository.findByEmail(email).get()
+            memberRepository.findByEmail(email)
+                .orElseThrow {
+                    CustomException(MemberErrorCode.MEMBER_NOT_FOUND)
+                }
         )
     }
 

--- a/src/main/kotlin/seugi/server/domain/member/adapter/out/MemberAdapter.kt
+++ b/src/main/kotlin/seugi/server/domain/member/adapter/out/MemberAdapter.kt
@@ -16,19 +16,19 @@ class MemberAdapter (
 
     override fun saveMember(member: Member) {
         memberRepository.save(
-            memberMapper.returnMemberToMemberEntityWithoutId(member)
+            memberMapper.toEntity(member)
         )
     }
 
     override fun loadMemberWithId(id: Long): Member {
-        return memberMapper.returnMemberEntityToMember(
+        return memberMapper.toDomain(
             memberRepository.findById(id).get()
         )
     }
 
     override fun loadMemberWithEmail(email: String): Member {
-        return memberMapper.returnMemberEntityToMember(
-            memberRepository.findByEmail(email)
+        return memberMapper.toDomain(
+            memberRepository.findByEmail(email).get()
         )
     }
 

--- a/src/main/kotlin/seugi/server/domain/member/adapter/out/mapper/MemberMapper.kt
+++ b/src/main/kotlin/seugi/server/domain/member/adapter/out/mapper/MemberMapper.kt
@@ -4,32 +4,34 @@ import org.springframework.stereotype.Component
 import seugi.server.domain.member.adapter.out.entity.MemberEntity
 import seugi.server.domain.member.application.model.Member
 import seugi.server.domain.member.application.model.value.*
+import seugi.server.global.common.Mapper
 
 @Component
-class MemberMapper {
-    fun returnMemberToMemberEntityWithoutId(member: Member): MemberEntity {
-        return MemberEntity(
-            name = member.name.value,
-            email = member.email.value,
-            password = member.password.value,
-            birth = member.birth.value,
-            loginId = member.loginId.value,
-            provider = member.provider.value,
-            providerId = member.providerId.value
+class MemberMapper: Mapper<Member, MemberEntity> {
+
+    override fun toDomain(entity: MemberEntity): Member {
+        return Member (
+            id = MemberId(entity.id),
+            name = MemberName(entity.name),
+            email = MemberEmail(entity.email),
+            password = MemberPassword(entity.password),
+            birth = MemberBirth(entity.birth),
+            role = MemberRole(entity.role),
+            loginId = MemberLoginId(entity.loginId),
+            provider = MemberProvider(entity.provider),
+            providerId = MemberProviderId(entity.providerId)
         )
     }
 
-    fun returnMemberEntityToMember(memberEntity: MemberEntity): Member {
-        return Member (
-            id = MemberId(memberEntity.id),
-            name = MemberName(memberEntity.name),
-            email = MemberEmail(memberEntity.email),
-            password = MemberPassword(memberEntity.password),
-            birth = MemberBirth(memberEntity.birth),
-            role = MemberRole(memberEntity.role),
-            loginId = MemberLoginId(memberEntity.loginId),
-            provider = MemberProvider(memberEntity.provider),
-            providerId = MemberProviderId(memberEntity.providerId)
+    override fun toEntity(domain: Member): MemberEntity {
+        return MemberEntity(
+            name = domain.name.value,
+            email = domain.email.value,
+            password = domain.password.value,
+            birth = domain.birth.value,
+            loginId = domain.loginId.value,
+            provider = domain.provider.value,
+            providerId = domain.providerId.value
         )
     }
 

--- a/src/main/kotlin/seugi/server/domain/member/adapter/out/repository/MemberRepository.kt
+++ b/src/main/kotlin/seugi/server/domain/member/adapter/out/repository/MemberRepository.kt
@@ -3,11 +3,12 @@ package seugi.server.domain.member.adapter.out.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import seugi.server.domain.member.adapter.out.entity.MemberEntity
+import java.util.Optional
 
 @Repository
 interface MemberRepository: JpaRepository<MemberEntity, Long> {
 
-    fun findByEmail(email: String): MemberEntity
+    fun findByEmail(email: String): Optional<MemberEntity>
 
     fun existsByEmail(email: String): Boolean
 

--- a/src/main/kotlin/seugi/server/domain/member/application/service/LoginMemberService.kt
+++ b/src/main/kotlin/seugi/server/domain/member/application/service/LoginMemberService.kt
@@ -1,5 +1,6 @@
 package seugi.server.domain.member.application.service
 
+import org.springframework.http.HttpStatus
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.stereotype.Service
 import seugi.server.domain.member.adapter.`in`.dto.LoginMemberDTO
@@ -8,7 +9,7 @@ import seugi.server.domain.member.port.`in`.LoginMemberUseCase
 import seugi.server.domain.member.port.out.LoadMemberPort
 import seugi.server.global.auth.jwt.JwtInfo
 import seugi.server.global.auth.jwt.JwtUtils
-import seugi.server.global.exception.CustomErrorCode
+import seugi.server.global.auth.jwt.exception.JwtErrorCode
 import seugi.server.global.exception.CustomException
 import seugi.server.global.response.BaseResponse
 
@@ -23,18 +24,14 @@ class LoginMemberService (
         val member: Member = loadMemberPort.loadMemberWithEmail(memberDTO.email)
 
         if (!bCryptPasswordEncoder.matches(memberDTO.password, member.password.value)) {
-            throw CustomException(CustomErrorCode.JWT_MEMBER_NOT_MATCH)
+            throw CustomException(JwtErrorCode.JWT_MEMBER_NOT_MATCH)
         }
 
         return BaseResponse (
-            code = 200,
+            status = HttpStatus.OK,
             success = true,
             message = "토큰 발급 성공 !!",
-            data = arrayListOf(
-                jwtUtils.generate(
-                    member
-                )
-            )
+            data = jwtUtils.generate(member)
         )
     }
 }

--- a/src/main/kotlin/seugi/server/domain/member/application/service/RegisterMemberService.kt
+++ b/src/main/kotlin/seugi/server/domain/member/application/service/RegisterMemberService.kt
@@ -1,15 +1,17 @@
 package seugi.server.domain.member.application.service
 
+import org.springframework.http.HttpStatus
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.web.bind.annotation.RequestBody
 import seugi.server.domain.member.adapter.`in`.dto.RegisterMemberDTO
 import seugi.server.domain.member.application.model.Member
 import seugi.server.domain.member.application.model.value.*
+import seugi.server.domain.member.exception.MemberErrorCode
 import seugi.server.domain.member.port.`in`.RegisterMemberUseCase
 import seugi.server.domain.member.port.out.ExistMemberPort
 import seugi.server.domain.member.port.out.SaveMemberPort
-import seugi.server.global.exception.CustomErrorCode
+import seugi.server.global.auth.jwt.exception.JwtErrorCode
 import seugi.server.global.exception.CustomException
 import seugi.server.global.response.BaseResponse
 
@@ -36,15 +38,14 @@ class RegisterMemberService (
         )
 
         if (existMemberPort.existMemberWithEmail(member.email.value)) {
-            throw CustomException(CustomErrorCode.MEMBER_ALREADY_EXIST)
+            throw CustomException(MemberErrorCode.MEMBER_ALREADY_EXIST)
         } else {
             saveMemberPort.saveMember(member)
 
             return BaseResponse (
-                code = 200,
+                status = HttpStatus.OK,
                 success = true,
                 message = "회원가입 성공 !!",
-                data = emptyList()
             )
         }
     }

--- a/src/main/kotlin/seugi/server/domain/member/exception/MemberErrorCode.kt
+++ b/src/main/kotlin/seugi/server/domain/member/exception/MemberErrorCode.kt
@@ -1,0 +1,15 @@
+package seugi.server.domain.member.exception
+
+import org.springframework.http.HttpStatus
+import seugi.server.global.exception.CustomErrorCode
+
+enum class MemberErrorCode (
+    override val status: HttpStatus,
+    override val state: String,
+    override val message: String,
+) : CustomErrorCode {
+
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-001", "멤버를 찾을 수 없네"),
+    MEMBER_ALREADY_EXIST(HttpStatus.CONFLICT, "MEMBER-002", "멤버가 이미 존재한다"),
+
+}

--- a/src/main/kotlin/seugi/server/global/auth/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/seugi/server/global/auth/jwt/JwtAuthenticationFilter.kt
@@ -26,15 +26,14 @@ class JwtAuthenticationFilter(
         if (token != null && token.startsWith("Bearer ")) {
             token = jwtUtils.getToken(token)
 
-            try  {
-                jwtUtils.isExpired(token)
-            } catch (e: ExpiredJwtException) {
+            if (!jwtUtils.isExpired(token)) {
+                val authentication: Authentication = jwtUtils.getAuthentication(token)
+
+                SecurityContextHolder.getContext().authentication = authentication
+            } else {
                 setErrorResponse(response, CustomErrorCode.JWT_TOKEN_EXPIRED)
+                return
             }
-
-            val authentication: Authentication = jwtUtils.getAuthentication(token)
-
-            SecurityContextHolder.getContext().authentication = authentication
         }
 
         doFilter(request, response, filterChain)
@@ -45,7 +44,7 @@ class JwtAuthenticationFilter(
         errorCode: CustomErrorCode
     ) {
         response.status = errorCode.code
-        response.contentType = "application/json"
+        response.contentType = "application/json;charset=UTF-8"
 
         response.writer.write(
             objectMapper.writeValueAsString(

--- a/src/main/kotlin/seugi/server/global/auth/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/seugi/server/global/auth/jwt/JwtAuthenticationFilter.kt
@@ -1,14 +1,13 @@
 package seugi.server.global.auth.jwt
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import io.jsonwebtoken.ExpiredJwtException
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.filter.OncePerRequestFilter
-import seugi.server.global.exception.CustomErrorCode
+import seugi.server.global.auth.jwt.exception.JwtErrorCode
 import seugi.server.global.response.BaseResponse
 
 class JwtAuthenticationFilter(
@@ -31,7 +30,7 @@ class JwtAuthenticationFilter(
 
                 SecurityContextHolder.getContext().authentication = authentication
             } else {
-                setErrorResponse(response, CustomErrorCode.JWT_TOKEN_EXPIRED)
+                setErrorResponse(response, JwtErrorCode.JWT_TOKEN_EXPIRED)
                 return
             }
         }
@@ -41,18 +40,18 @@ class JwtAuthenticationFilter(
 
     private fun setErrorResponse(
         response: HttpServletResponse,
-        errorCode: CustomErrorCode
+        errorCode: JwtErrorCode
     ) {
-        response.status = errorCode.code
+        response.status = errorCode.status.value()
         response.contentType = "application/json;charset=UTF-8"
 
         response.writer.write(
             objectMapper.writeValueAsString(
                 BaseResponse<String> (
-                    code = errorCode.code,
+                    status = errorCode.status,
+                    state = errorCode.state,
                     success = false,
-                    message = errorCode.msg,
-                    data = emptyList()
+                    message = errorCode.message,
                 )
             )
         )

--- a/src/main/kotlin/seugi/server/global/auth/jwt/JwtUtils.kt
+++ b/src/main/kotlin/seugi/server/global/auth/jwt/JwtUtils.kt
@@ -1,5 +1,6 @@
 package seugi.server.global.auth.jwt
 
+import io.jsonwebtoken.ExpiredJwtException
 import io.jsonwebtoken.Jwts
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.Authentication
@@ -28,7 +29,12 @@ class JwtUtils (
     }
 
     fun isExpired(token: String): Boolean {
-        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).payload.expiration.before(Date())
+        try {
+            Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token)
+            return false
+        } catch (e: ExpiredJwtException) {
+            return true
+        }
     }
 
     fun getToken(token: String): String {

--- a/src/main/kotlin/seugi/server/global/auth/jwt/exception/JwtErrorCode.kt
+++ b/src/main/kotlin/seugi/server/global/auth/jwt/exception/JwtErrorCode.kt
@@ -1,0 +1,15 @@
+package seugi.server.global.auth.jwt.exception
+
+import org.springframework.http.HttpStatus
+import seugi.server.global.exception.CustomErrorCode
+
+enum class JwtErrorCode (
+    override val status: HttpStatus,
+    override val state: String,
+    override val message: String,
+): CustomErrorCode {
+
+    JWT_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "LOGIN-001", "토큰 만료다"),
+    JWT_MEMBER_NOT_MATCH(HttpStatus.UNAUTHORIZED, "LOGIN-002", "비밀번호 일치 노노")
+
+}

--- a/src/main/kotlin/seugi/server/global/common/Mapper.kt
+++ b/src/main/kotlin/seugi/server/global/common/Mapper.kt
@@ -1,0 +1,24 @@
+package seugi.server.global.common
+
+/**
+ * Domain 클래스를 Entity 클래스로, Entity 클래스를 Domain 클래스로 변환해주는 인터페이스 <br>
+ * 반드시 각각의 타입은 변환이 가능한 형태이어야 합니다.
+ * @param <D> Domain 모듈에 위치한 Domain 클래스
+ * @param <E> 인프라스트럭쳐 모듈에 위치한 Entity 클래스
+ */
+interface Mapper<D, E> {
+
+    /**
+     * Entity 클래스를 인자로 Domain 클래스로 변환합니다.
+     * @param entity Entity 인스턴스를 인자로 받습니다.
+     * @return Domain 클래스를 반환합니다.
+     */
+    fun toDomain(entity: E): D
+
+    /**
+     * Domain 클래스를 인자로 Entity 클래스로 변환합니다.
+     * @param domain Domain 인스턴스를 인자로 받습니다.
+     * @return Entity 클래스를 반환합니다.
+     */
+    fun toEntity(domain: D): E
+}

--- a/src/main/kotlin/seugi/server/global/exception/CustomErrorCode.kt
+++ b/src/main/kotlin/seugi/server/global/exception/CustomErrorCode.kt
@@ -1,15 +1,11 @@
 package seugi.server.global.exception
 
-enum class CustomErrorCode (
-    val code: Int,
-    val msg: String
-) {
+import org.springframework.http.HttpStatus
 
-    // 회원가입
-    MEMBER_ALREADY_EXIST(400, "이메일 중복됨"),
+interface CustomErrorCode {
 
-    // JWT
-    JWT_TOKEN_EXPIRED(400, "토큰 만료됨"),
-    JWT_MEMBER_NOT_MATCH(400, "비밀번호가 일치하지 않음")
+    val status: HttpStatus
+    val state: String
+    val message: String
 
 }

--- a/src/main/kotlin/seugi/server/global/exception/CustomExceptionHandler.kt
+++ b/src/main/kotlin/seugi/server/global/exception/CustomExceptionHandler.kt
@@ -1,5 +1,6 @@
 package seugi.server.global.exception
 
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import seugi.server.global.response.BaseResponse
@@ -8,13 +9,15 @@ import seugi.server.global.response.BaseResponse
 class CustomExceptionHandler {
 
     @ExceptionHandler(CustomException::class)
-    fun handleCustomException(customException: CustomException): BaseResponse<String> {
-        return BaseResponse (
-            code = customException.customErrorCode.code,
+    fun handleCustomException(customException: CustomException): ResponseEntity<Any> {
+        val response = BaseResponse<Unit>(
+            status = customException.customErrorCode.status,
+            state = customException.customErrorCode.state,
             success = false,
-            message = customException.customErrorCode.msg,
-            data = emptyList()
+            message = customException.customErrorCode.message,
         )
+
+        return ResponseEntity(response, customException.customErrorCode.status)
     }
 
 }

--- a/src/main/kotlin/seugi/server/global/response/BaseResponse.kt
+++ b/src/main/kotlin/seugi/server/global/response/BaseResponse.kt
@@ -1,10 +1,16 @@
 package seugi.server.global.response
 
+import com.fasterxml.jackson.annotation.JsonInclude
+import org.springframework.http.HttpStatus
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class BaseResponse<T> (
 
-    val code: Int,
+    val status: HttpStatus,
     val success: Boolean,
+    val state: String? = "NONE",
     val message: String,
-    val data: List<T>
+    val data: T? = null
 
 )
+


### PR DESCRIPTION
🐳 한 일
- JwtAuthenticationFilter & JwtUtils 토큰 만료 검사 로직 고침
- Mapper 인터페이스를 도메인 별 Mapper에서 구현
- 리스폰스 모두 갖다 수정해버림
- 로그인 시 멤버 못찾으면 CustomException 터트림