### PR TITLE
채팅방 검색 로직 구현

### DIFF
--- a/src/main/kotlin/com/seugi/api/domain/chat/application/service/room/ChatRoomService.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/application/service/room/ChatRoomService.kt
@@ -3,6 +3,7 @@ package com.seugi.api.domain.chat.application.service.room
 import com.seugi.api.domain.chat.domain.enums.type.RoomType
 import com.seugi.api.domain.chat.domain.room.model.Room
 import com.seugi.api.domain.chat.presentation.room.dto.request.CreateRoomRequest
+import com.seugi.api.domain.chat.presentation.room.dto.request.SearchRoomRequest
 import com.seugi.api.global.response.BaseResponse
 
 
@@ -13,5 +14,7 @@ interface ChatRoomService {
     fun getRooms(workspaceId: String, userId: Long, type: RoomType) : BaseResponse<List<Room>>
 
     fun leftRoom(userId: Long, roomId: Long) : BaseResponse<Unit>
+
+    fun searchRoomNameIn(searchRoomRequest: SearchRoomRequest, type: RoomType, userId: Long): BaseResponse<List<Room>>
 
 }

--- a/src/main/kotlin/com/seugi/api/domain/chat/application/service/room/ChatRoomServiceImpl.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/application/service/room/ChatRoomServiceImpl.kt
@@ -11,9 +11,11 @@ import com.seugi.api.domain.chat.domain.room.ChatRoomEntity
 import com.seugi.api.domain.chat.domain.room.ChatRoomRepository
 import com.seugi.api.domain.chat.domain.room.mapper.RoomMapper
 import com.seugi.api.domain.chat.domain.room.model.Room
+import com.seugi.api.domain.chat.exception.ChatErrorCode
 import com.seugi.api.domain.chat.presentation.room.dto.request.CreateRoomRequest
 import com.seugi.api.domain.chat.presentation.room.dto.request.SearchRoomRequest
 import com.seugi.api.domain.member.adapter.out.repository.MemberRepository
+import com.seugi.api.global.exception.CustomException
 import com.seugi.api.global.response.BaseResponse
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
@@ -133,14 +135,21 @@ class ChatRoomServiceImpl(
 
         when(type){
             PERSONAL -> {
-
-
-
                 return BaseResponse(
                     status = HttpStatus.OK.value(),
                     state = "OK",
                     success = true,
-                    message = "방 찾기 성공"
+                    message = "방 찾기 성공",
+                    data = joined.mapNotNull {
+                        val name = memberRepository.findById(it.joinUserId.firstOrNull { id -> id != userId }!!).get().name
+                        if (name.contains(searchRoomRequest.word)) {
+                            val chatRoom = chatRoomRepository.findById(it.chatRoomId).orElseThrow{CustomException(ChatErrorCode.CHAT_ROOM_NOT_FOUND)}
+                            chatRoom.chatName = name
+                            chatRoomMapper.toDomain(chatRoom)
+                        } else {
+                            null
+                        }
+                    }
                 )
             }
             GROUP -> {

--- a/src/main/kotlin/com/seugi/api/domain/chat/application/service/room/ChatRoomServiceImpl.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/application/service/room/ChatRoomServiceImpl.kt
@@ -12,6 +12,7 @@ import com.seugi.api.domain.chat.domain.room.ChatRoomRepository
 import com.seugi.api.domain.chat.domain.room.mapper.RoomMapper
 import com.seugi.api.domain.chat.domain.room.model.Room
 import com.seugi.api.domain.chat.presentation.room.dto.request.CreateRoomRequest
+import com.seugi.api.domain.chat.presentation.room.dto.request.SearchRoomRequest
 import com.seugi.api.domain.member.adapter.out.repository.MemberRepository
 import com.seugi.api.global.response.BaseResponse
 import org.springframework.http.HttpStatus
@@ -124,6 +125,37 @@ class ChatRoomServiceImpl(
             success = true,
             message = "방 나가기 성공"
         )
+    }
+
+    @Transactional(readOnly = true)
+    override fun searchRoomNameIn(searchRoomRequest: SearchRoomRequest, type: RoomType, userId: Long): BaseResponse<List<Room>> {
+        val joined: List<Joined> = joinedService.findByJoinedUserId(userId = userId, roomType = type, workspaceId = searchRoomRequest.workspaceId)
+
+        when(type){
+            PERSONAL -> {
+
+
+
+                return BaseResponse(
+                    status = HttpStatus.OK.value(),
+                    state = "OK",
+                    success = true,
+                    message = "방 찾기 성공"
+                )
+            }
+            GROUP -> {
+                return BaseResponse(
+                    status = HttpStatus.OK.value(),
+                    state = "OK",
+                    success = true,
+                    message = "방 찾기 성공",
+                    data = joined.mapNotNull { chatRoomRepository.searchRoom(it.chatRoomId, searchRoomRequest.word) }
+                )
+            }
+
+        }
+
+
     }
 
 }

--- a/src/main/kotlin/com/seugi/api/domain/chat/domain/room/ChatRoomRepository.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/domain/room/ChatRoomRepository.kt
@@ -4,5 +4,5 @@ import com.seugi.api.domain.chat.domain.room.model.Room
 import org.springframework.data.repository.CrudRepository
 
 interface ChatRoomRepository : CrudRepository <ChatRoomEntity, Long> , ChatRoomRepositoryCustom{
-    override fun searchRoom(input: String): List<Room>
+    override fun searchRoom(chatRoomId: Long, input: String): Room?
 }

--- a/src/main/kotlin/com/seugi/api/domain/chat/domain/room/ChatRoomRepository.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/domain/room/ChatRoomRepository.kt
@@ -1,5 +1,8 @@
 package com.seugi.api.domain.chat.domain.room
 
+import com.seugi.api.domain.chat.domain.room.model.Room
 import org.springframework.data.repository.CrudRepository
 
-interface ChatRoomRepository : CrudRepository <ChatRoomEntity, Long> , ChatRoomRepositoryCustom
+interface ChatRoomRepository : CrudRepository <ChatRoomEntity, Long> , ChatRoomRepositoryCustom{
+    override fun searchRoom(input: String): List<Room>
+}

--- a/src/main/kotlin/com/seugi/api/domain/chat/domain/room/ChatRoomRepositoryCustom.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/domain/room/ChatRoomRepositoryCustom.kt
@@ -1,4 +1,7 @@
 package com.seugi.api.domain.chat.domain.room
 
+import com.seugi.api.domain.chat.domain.room.model.Room
+
 interface ChatRoomRepositoryCustom {
+    fun searchRoom(input: String): List<Room>
 }

--- a/src/main/kotlin/com/seugi/api/domain/chat/domain/room/ChatRoomRepositoryCustom.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/domain/room/ChatRoomRepositoryCustom.kt
@@ -3,5 +3,5 @@ package com.seugi.api.domain.chat.domain.room
 import com.seugi.api.domain.chat.domain.room.model.Room
 
 interface ChatRoomRepositoryCustom {
-    fun searchRoom(input: String): List<Room>
+    fun searchRoom(chatRoomId: Long, input: String): Room?
 }

--- a/src/main/kotlin/com/seugi/api/domain/chat/domain/room/ChatRoomRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/domain/room/ChatRoomRepositoryCustomImpl.kt
@@ -1,4 +1,23 @@
 package com.seugi.api.domain.chat.domain.room
 
-class ChatRoomRepositoryCustomImpl : ChatRoomRepositoryCustom {
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.seugi.api.domain.chat.domain.room.mapper.RoomMapper
+import com.seugi.api.domain.chat.domain.room.model.Room
+
+class ChatRoomRepositoryCustomImpl(
+    private val jpaQueryFactory: JPAQueryFactory,
+    private val chatRoomMapper: RoomMapper
+) : ChatRoomRepositoryCustom {
+
+    private val chatRoomEntity: QChatRoomEntity = QChatRoomEntity.chatRoomEntity
+
+    override fun searchRoom(input: String): List<Room> {
+        val rooms = jpaQueryFactory
+            .selectFrom(chatRoomEntity)
+            .where(chatRoomEntity.chatName.contains(input))
+            .fetch()
+
+        return rooms.map { chatRoomMapper.toDomain(it) }
+    }
+
 }

--- a/src/main/kotlin/com/seugi/api/domain/chat/domain/room/ChatRoomRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/domain/room/ChatRoomRepositoryCustomImpl.kt
@@ -11,13 +11,13 @@ class ChatRoomRepositoryCustomImpl(
 
     private val chatRoomEntity: QChatRoomEntity = QChatRoomEntity.chatRoomEntity
 
-    override fun searchRoom(input: String): List<Room> {
-        val rooms = jpaQueryFactory
+    override fun searchRoom(chatRoomId: Long ,input: String): Room? {
+        val room = jpaQueryFactory
             .selectFrom(chatRoomEntity)
-            .where(chatRoomEntity.chatName.contains(input))
-            .fetch()
+            .where(chatRoomEntity.id.eq(chatRoomId), chatRoomEntity.chatName.contains(input))
+            .fetchFirst()
 
-        return rooms.map { chatRoomMapper.toDomain(it) }
+        return room?.let { chatRoomMapper.toDomain(it) }
     }
 
 }

--- a/src/main/kotlin/com/seugi/api/domain/chat/presentation/room/controller/GroupChatController.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/presentation/room/controller/GroupChatController.kt
@@ -5,6 +5,7 @@ import com.seugi.api.domain.chat.application.service.room.ChatRoomService
 import com.seugi.api.domain.chat.domain.enums.type.RoomType
 import com.seugi.api.domain.chat.domain.room.model.Room
 import com.seugi.api.domain.chat.presentation.room.dto.request.CreateRoomRequest
+import com.seugi.api.domain.chat.presentation.room.dto.request.SearchRoomRequest
 import com.seugi.api.global.common.annotation.GetAuthenticatedId
 import com.seugi.api.global.response.BaseResponse
 
@@ -25,6 +26,14 @@ class GroupChatController(
         @RequestBody createRoomRequest: CreateRoomRequest
     ) : BaseResponse<Long> {
         return chatRoomService.createChatRoom(createRoomRequest, id, RoomType.GROUP)
+    }
+
+    @GetMapping("/search")
+    fun searchRoom(
+        @GetAuthenticatedId userId: Long,
+        @RequestBody searchRoomRequest: SearchRoomRequest
+    ): BaseResponse<List<Room>> {
+        return chatRoomService.searchRoomNameIn(searchRoomRequest, RoomType.GROUP, userId)
     }
 
     @GetMapping("/search/{workspaceID}")

--- a/src/main/kotlin/com/seugi/api/domain/chat/presentation/room/controller/PersonalChatController.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/presentation/room/controller/PersonalChatController.kt
@@ -5,6 +5,7 @@ import com.seugi.api.domain.chat.application.service.room.ChatRoomService
 import com.seugi.api.domain.chat.domain.enums.type.RoomType
 import com.seugi.api.domain.chat.domain.room.model.Room
 import com.seugi.api.domain.chat.presentation.room.dto.request.CreateRoomRequest
+import com.seugi.api.domain.chat.presentation.room.dto.request.SearchRoomRequest
 import com.seugi.api.global.common.annotation.GetAuthenticatedId
 import com.seugi.api.global.response.BaseResponse
 
@@ -17,7 +18,7 @@ import com.seugi.api.global.response.BaseResponse
 @RestController
 @RequestMapping("/chat/personal")
 class PersonalChatController(
-    private val chatRoomService: ChatRoomService,
+    private val chatRoomService: ChatRoomService
 ) {
 
     @PostMapping("/create")
@@ -26,6 +27,14 @@ class PersonalChatController(
         @RequestBody createRoomRequest: CreateRoomRequest
     ) : BaseResponse<Long> {
         return chatRoomService.createChatRoom(createRoomRequest, id, RoomType.PERSONAL)
+    }
+
+    @GetMapping("/search")
+    fun searchRoom(
+        @GetAuthenticatedId userId: Long,
+        @RequestBody searchRoomRequest: SearchRoomRequest
+    ): BaseResponse<List<Room>> {
+        return chatRoomService.searchRoomNameIn(searchRoomRequest, RoomType.PERSONAL, userId)
     }
 
     @GetMapping("/search/{workspaceId}")

--- a/src/main/kotlin/com/seugi/api/domain/chat/presentation/room/dto/request/SearchRoomRequest.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/presentation/room/dto/request/SearchRoomRequest.kt
@@ -1,0 +1,6 @@
+package com.seugi.api.domain.chat.presentation.room.dto.request
+
+data class SearchRoomRequest(
+    val workspaceId: String = "",
+    val word: String = "",
+)


### PR DESCRIPTION
# #️⃣ 연관된 이슈

> #74 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

채팅방 검색 로직 (개인, 단체) 를 구현하였습니다.

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

채팅방 검색시 비효율적인 (채팅방이라는 도메인에 디비가 MySQL과 MongoDB로 나누어져서 2번 검색해야하는) 로직이라.
이걸 디비를 하나로 통일할까 고민중입니다.


### 📎 ETC
> 기타

근데 2개 연결해도 데이터가 아직 많이 없어서 속도는 빠르긴해요 나중에 테스트해봐야겠지만