### PR TITLE
Fix :: Member 도메인 Mapper 도메인 모델 내 id가 null일 때 강제 참조로 인해 NPE가 발생하는 문제 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ application-mongo.yml
 application-smtp.yml
 application-mq.yml
 application-aws.yml
+application-space.yml
+application-act.yml

--- a/src/main/kotlin/com/seugi/api/domain/chat/domain/chat/mapper/MessageMapper.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/domain/chat/mapper/MessageMapper.kt
@@ -59,7 +59,7 @@ class MessageMapper : Mapper<Message, MessageEntity> {
 
      fun toMember(entity: MemberEntity): MessageMember {
         return MessageMember (
-            id =  entity.id,
+            id =  entity.id!!,
             name = entity.name
         )
     }

--- a/src/main/kotlin/com/seugi/api/domain/member/adapter/out/entity/MemberEntity.kt
+++ b/src/main/kotlin/com/seugi/api/domain/member/adapter/out/entity/MemberEntity.kt
@@ -13,7 +13,7 @@ data class MemberEntity (
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    var id: Long = 0,
+    var id: Long? = null,
 
     @Column(nullable = false)
     var name: String = "",

--- a/src/main/kotlin/com/seugi/api/domain/member/adapter/out/mapper/MemberMapper.kt
+++ b/src/main/kotlin/com/seugi/api/domain/member/adapter/out/mapper/MemberMapper.kt
@@ -27,7 +27,7 @@ class MemberMapper: Mapper<Member, MemberEntity> {
 
     override fun toEntity(domain: Member): MemberEntity {
         return MemberEntity(
-            id = domain.id!!.value,
+            id = domain.id?.value ?: 0,
             name = domain.name.value,
             email = domain.email.value,
             picture = domain.picture.value,

--- a/src/main/kotlin/com/seugi/api/domain/member/adapter/out/mapper/MemberMapper.kt
+++ b/src/main/kotlin/com/seugi/api/domain/member/adapter/out/mapper/MemberMapper.kt
@@ -11,7 +11,7 @@ class MemberMapper: Mapper<Member, MemberEntity> {
 
     override fun toDomain(entity: MemberEntity): Member {
         return Member (
-            id = MemberId(entity.id),
+            id = MemberId(entity.id!!),
             name = MemberName(entity.name),
             email = MemberEmail(entity.email),
             picture = MemberPicture(entity.picture),


### PR DESCRIPTION
# #️⃣ 연관된 이슈

> #78

## 📝 작업 내용

> Member 도메인 Mapper 도메인 모델 내 id가 null일 때 강제 참조로 인해 NPE가 발생하는 문제 해결

## 💬 리뷰 요구사항(선택)

> 😢

### 📎 ETC
> 😢😢😢😢
