### PR TITLE
Fix :: 방 생성, 나갈시 메시지값이 null이라 NPE 발생하던 문제 해결

### DIFF
--- a/src/main/kotlin/com/seugi/api/domain/chat/application/service/room/ChatRoomServiceImpl.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/application/service/room/ChatRoomServiceImpl.kt
@@ -67,6 +67,7 @@ class ChatRoomServiceImpl(
             chatMessageDto = ChatMessageDto(
                 type = Type.ENTER,
                 roomId = chatRoomId,
+                message = "",
                 eventList = createRoomRequest.joinUsers,
             ),
             userId = userId
@@ -140,6 +141,7 @@ class ChatRoomServiceImpl(
             chatMessageDto = ChatMessageDto(
                 type = Type.LEFT,
                 roomId = roomId,
+                message = "",
                 eventList = eventList.toMutableList()
             ),
             userId = userId


### PR DESCRIPTION
## 이슈

- 개인 채팅방 생성이 안되던 버그

### 문제

- 이벤트 메시지를 보낼때 메시지 값이 null이라 발생

### 해결여부

O