### PR TITLE
Feat :: 멤버 정보 수정 API

### DIFF
--- a/src/main/kotlin/com/seugi/api/domain/member/adapter/in/controller/EditMemberController.kt
+++ b/src/main/kotlin/com/seugi/api/domain/member/adapter/in/controller/EditMemberController.kt
@@ -1,21 +1,23 @@
 package com.seugi.api.domain.member.adapter.`in`.controller
 
+import com.seugi.api.domain.member.adapter.`in`.dto.req.EditMemberRequest
 import com.seugi.api.domain.member.application.port.`in`.EditMemberUseCase
 import com.seugi.api.global.common.annotation.GetAuthenticatedId
 import com.seugi.api.global.response.BaseResponse
-import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/member/edit")
+@RequestMapping("/member")
 class EditMemberController (
     private val editMemberUseCase: EditMemberUseCase
 ) {
 
-    @GetMapping("/picture")
-    fun editPicture(url: String, @GetAuthenticatedId id: Long) : BaseResponse<Unit> {
-        return editMemberUseCase.editPicture(url, id)
+    @PatchMapping("/edit")
+    fun editMember(@RequestBody dto: EditMemberRequest, @GetAuthenticatedId id: Long) : BaseResponse<Unit> {
+        return editMemberUseCase.editMember(dto, id)
     }
 
 }

--- a/src/main/kotlin/com/seugi/api/domain/member/adapter/in/dto/req/EditMemberRequest.kt
+++ b/src/main/kotlin/com/seugi/api/domain/member/adapter/in/dto/req/EditMemberRequest.kt
@@ -1,0 +1,11 @@
+package com.seugi.api.domain.member.adapter.`in`.dto.req
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+class EditMemberRequest (
+
+    @JsonProperty("picture") val picture: String,
+    @JsonProperty("name") val name: String,
+    @JsonProperty("birth") val birth: String,
+
+)

--- a/src/main/kotlin/com/seugi/api/domain/member/adapter/out/entity/MemberEntity.kt
+++ b/src/main/kotlin/com/seugi/api/domain/member/adapter/out/entity/MemberEntity.kt
@@ -1,12 +1,10 @@
 package com.seugi.api.domain.member.adapter.out.entity
 
-import com.seugi.api.domain.profile.adapter.out.entity.ProfileEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
-import jakarta.persistence.OneToMany
 
 @Entity
 data class MemberEntity (

--- a/src/main/kotlin/com/seugi/api/domain/member/application/model/Member.kt
+++ b/src/main/kotlin/com/seugi/api/domain/member/application/model/Member.kt
@@ -1,5 +1,6 @@
 package com.seugi.api.domain.member.application.model
 
+import com.seugi.api.domain.member.adapter.`in`.dto.req.EditMemberRequest
 import com.seugi.api.domain.member.application.model.value.*
 
 data class Member (
@@ -15,4 +16,12 @@ data class Member (
     val provider: MemberProvider,
     val providerId: MemberProviderId,
 
-)
+) {
+
+    fun editMember (dto: EditMemberRequest) {
+        this.picture = MemberPicture(dto.picture)
+        this.name = MemberName(dto.name)
+        this.birth = MemberBirth(dto.birth)
+    }
+
+}

--- a/src/main/kotlin/com/seugi/api/domain/member/application/port/in/EditMemberUseCase.kt
+++ b/src/main/kotlin/com/seugi/api/domain/member/application/port/in/EditMemberUseCase.kt
@@ -1,9 +1,10 @@
 package com.seugi.api.domain.member.application.port.`in`
 
+import com.seugi.api.domain.member.adapter.`in`.dto.req.EditMemberRequest
 import com.seugi.api.global.response.BaseResponse
 
 interface EditMemberUseCase {
 
-    fun editPicture(url: String, id: Long): BaseResponse<Unit>
+    fun editMember(dto: EditMemberRequest, id: Long): BaseResponse<Unit>
 
 }

--- a/src/main/kotlin/com/seugi/api/domain/member/application/service/EditMemberService.kt
+++ b/src/main/kotlin/com/seugi/api/domain/member/application/service/EditMemberService.kt
@@ -1,7 +1,7 @@
 package com.seugi.api.domain.member.application.service
 
+import com.seugi.api.domain.member.adapter.`in`.dto.req.EditMemberRequest
 import com.seugi.api.domain.member.adapter.out.MemberAdapter
-import com.seugi.api.domain.member.application.model.value.MemberPicture
 import com.seugi.api.domain.member.application.port.`in`.EditMemberUseCase
 import com.seugi.api.global.response.BaseResponse
 import org.springframework.http.HttpStatus
@@ -12,17 +12,17 @@ class EditMemberService (
     private val memberAdapter: MemberAdapter,
 ) : EditMemberUseCase {
 
-    override fun editPicture(url: String, id: Long): BaseResponse<Unit> {
+    override fun editMember(dto: EditMemberRequest, id: Long): BaseResponse<Unit> {
         val member = memberAdapter.loadMemberWithId(id)
 
-        member.picture = MemberPicture(url)
+        member.editMember(dto)
 
         memberAdapter.saveMember(member)
 
         return BaseResponse (
             status = HttpStatus.OK.value(),
             success = true,
-            message = "프로필 사진 변경 성공 !!"
+            message = "멤버 정보 변경 성공 !!"
         )
     }
 

--- a/src/main/kotlin/com/seugi/api/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/seugi/api/global/config/SecurityConfig.kt
@@ -50,6 +50,7 @@ class SecurityConfig (
             .authorizeHttpRequests {
                 it
                     .requestMatchers("/member/**", "/oauth2/**", "/email/**").permitAll()
+                    .requestMatchers("/member/edit", "/member/myInfo").hasRole("USER")
                     .requestMatchers("/stomp/**").permitAll()
                     .requestMatchers("$actuatorUrl/**").permitAll()
                     .anyRequest().authenticated()


### PR DESCRIPTION
# #️⃣ 연관된 이슈

> #112

## 📝 작업 내용

> 멤버 사진, 이름, 생년월일을 변경할 수 있는 API를 작성하였습니다

## 💬 리뷰 요구사항(선택)

> 이메일과 비밀번호를 변경하는 API를 만드는 편이 좋겠죠 ?

### 📎 ETC
> 다음은 조직도 기능입니다
