### PR TITLE
Refactor :: 채팅룸 ID 형변환 수정

### DIFF
--- a/src/main/kotlin/com/seugi/api/domain/chat/application/service/message/MessageService.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/application/service/message/MessageService.kt
@@ -14,7 +14,7 @@ interface MessageService {
     fun sendAndSaveMessage(chatMessageDto: ChatMessageDto, userId: Long)
     fun sendEventMessage(message: MessageEventDto, roomId: String)
     fun savaMessage(chatMessageDto: ChatMessageDto, userId: Long): Message
-    fun getMessages(chatRoomId: Long, userId: Long, pageable: Pageable): BaseResponse<GetMessageResponse>
+    fun getMessages(chatRoomId: String, userId: Long, pageable: Pageable): BaseResponse<GetMessageResponse>
 
     fun addEmojiToMessage(userId: Long, emoji: AddEmoji): BaseResponse<Unit>
     fun deleteEmojiToMessage(userId: Long, emoji: AddEmoji): BaseResponse<Unit>

--- a/src/main/kotlin/com/seugi/api/domain/chat/application/service/message/MessageServiceImpl.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/application/service/message/MessageServiceImpl.kt
@@ -66,13 +66,13 @@ class MessageServiceImpl(
     }
 
     @Transactional(readOnly = true)
-    override fun getMessages(chatRoomId: Long, userId: Long, pageable: Pageable): BaseResponse<GetMessageResponse> {
+    override fun getMessages(chatRoomId: String, userId: Long, pageable: Pageable): BaseResponse<GetMessageResponse> {
 
         val allMessages =
-            messageRepository.findByChatRoomIdEquals(chatRoomId, pageable).map { messageMapper.toDomain(it) }
+            messageRepository.findByChatRoomIdEquals(ObjectId(chatRoomId), pageable).map { messageMapper.toDomain(it) }
 
         val unreadMessages: List<MessageEntity> =
-            messageRepository.findByChatRoomIdEqualsAndReadNot(chatRoomId, setOf(userId))
+            messageRepository.findByChatRoomIdEqualsAndReadNot(ObjectId(chatRoomId), setOf(userId))
 
         if (unreadMessages.isNotEmpty()) {
             unreadMessages.map { it.read.add(userId) }

--- a/src/main/kotlin/com/seugi/api/domain/chat/domain/chat/MessageRepository.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/domain/chat/MessageRepository.kt
@@ -5,6 +5,6 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.mongodb.repository.MongoRepository
 
 interface MessageRepository : MongoRepository<MessageEntity, ObjectId> {
-    fun findByChatRoomIdEquals(chatRoomId: Long, pageable: Pageable): List<MessageEntity>
-    fun findByChatRoomIdEqualsAndReadNot(chatRoomId: Long, read: Set<Long>): List<MessageEntity>
+    fun findByChatRoomIdEquals(chatRoomId: ObjectId, pageable: Pageable): List<MessageEntity>
+    fun findByChatRoomIdEqualsAndReadNot(chatRoomId: ObjectId, read: Set<Long>): List<MessageEntity>
 }

--- a/src/main/kotlin/com/seugi/api/domain/chat/presentation/message/controller/MessageController.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/presentation/message/controller/MessageController.kt
@@ -57,9 +57,10 @@ class MessageController(
     @GetMapping("/search/{roomId}")
     fun getMessages(
         @GetAuthenticatedId userId: Long,
-        @PathVariable roomId: Long,
+        @PathVariable roomId: String,
         @PageableDefault(sort = ["id"], direction = Sort.Direction.DESC, size = 20) pageable: Pageable
     ): BaseResponse<GetMessageResponse> {
+        println("++++++++++++++++++++++++++++")
         return messageService.getMessages(
             chatRoomId = roomId,
             userId = userId,

--- a/src/main/kotlin/com/seugi/api/domain/chat/presentation/message/controller/MessageController.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/presentation/message/controller/MessageController.kt
@@ -60,7 +60,6 @@ class MessageController(
         @PathVariable roomId: String,
         @PageableDefault(sort = ["id"], direction = Sort.Direction.DESC, size = 20) pageable: Pageable
     ): BaseResponse<GetMessageResponse> {
-        println("++++++++++++++++++++++++++++")
         return messageService.getMessages(
             chatRoomId = roomId,
             userId = userId,


### PR DESCRIPTION
채팅룸 ID의 타입을 Long에서 String으로 변경하였습니다. 이에 따라 관련 서비스와 리포지토리의 메서드들을 수정하였습니다.

또한 조회시 String 으로 조회하여 문제가 발생한 부분을 ObjectID로 수정해서 문제를 해결하였습니다.