### PR TITLE
Fix :: 메시지 관련 타입 변경 및 로깅 추가

### DIFF
--- a/src/main/kotlin/com/seugi/api/domain/chat/application/service/message/MessageServiceImpl.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/application/service/message/MessageServiceImpl.kt
@@ -69,10 +69,14 @@ class MessageServiceImpl(
     override fun getMessages(chatRoomId: String, userId: Long, pageable: Pageable): BaseResponse<GetMessageResponse> {
 
         val allMessages =
-            messageRepository.findByChatRoomIdEquals(ObjectId(chatRoomId), pageable).map { messageMapper.toDomain(it) }
+            messageRepository.findByChatRoomIdEquals(chatRoomId, pageable).map { messageMapper.toDomain(it) }
+
+        for (message in allMessages) {
+            println(message)
+        }
 
         val unreadMessages: List<MessageEntity> =
-            messageRepository.findByChatRoomIdEqualsAndReadNot(ObjectId(chatRoomId), setOf(userId))
+            messageRepository.findByChatRoomIdEqualsAndReadNot(chatRoomId, setOf(userId))
 
         if (unreadMessages.isNotEmpty()) {
             unreadMessages.map { it.read.add(userId) }

--- a/src/main/kotlin/com/seugi/api/domain/chat/domain/chat/MessageRepository.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/domain/chat/MessageRepository.kt
@@ -5,6 +5,6 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.mongodb.repository.MongoRepository
 
 interface MessageRepository : MongoRepository<MessageEntity, ObjectId> {
-    fun findByChatRoomIdEquals(chatRoomId: ObjectId, pageable: Pageable): List<MessageEntity>
-    fun findByChatRoomIdEqualsAndReadNot(chatRoomId: ObjectId, read: Set<Long>): List<MessageEntity>
+    fun findByChatRoomIdEquals(chatRoomId: String, pageable: Pageable): List<MessageEntity>
+    fun findByChatRoomIdEqualsAndReadNot(chatRoomId: String, read: Set<Long>): List<MessageEntity>
 }


### PR DESCRIPTION
메시지를 조회하는 메서드에서 ChatRoomId의 타입을 ObjectId에서 String으로 변경하였습니다. 또한 모든 메시지를 가져와 로깅하는 과정을 추가하였습니다.