### PR TITLE
Refactor :: JWT 인증 필터 및 오류 타입 구조 개선

### DIFF
--- a/src/main/kotlin/com/seugi/api/domain/member/application/service/RefreshTokenService.kt
+++ b/src/main/kotlin/com/seugi/api/domain/member/application/service/RefreshTokenService.kt
@@ -4,9 +4,9 @@ import com.seugi.api.domain.member.application.port.`in`.RefreshTokenUseCase
 import com.seugi.api.domain.member.application.port.out.LoadMemberPort
 import com.seugi.api.global.auth.jwt.JwtUtils
 import com.seugi.api.global.auth.jwt.exception.JwtErrorCode
+import com.seugi.api.global.auth.jwt.exception.type.JwtErrorType
 import com.seugi.api.global.exception.CustomException
 import com.seugi.api.global.response.BaseResponse
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 
@@ -19,7 +19,7 @@ class RefreshTokenService (
     override fun refreshToken(token: String): BaseResponse<String> {
         val got = jwtUtils.getToken(token)
 
-        if (jwtUtils.isExpired(got)) {
+        if (jwtUtils.isExpired(got) == JwtErrorType.ExpiredJwtException) {
             throw CustomException(JwtErrorCode.JWT_TOKEN_EXPIRED)
         }
 

--- a/src/main/kotlin/com/seugi/api/domain/workspace/presentation/controller/WorkspaceController.kt
+++ b/src/main/kotlin/com/seugi/api/domain/workspace/presentation/controller/WorkspaceController.kt
@@ -15,7 +15,7 @@ class WorkspaceController(
     private val workspaceService: WorkspaceService
 ) {
 
-    @PostMapping("/")
+    @PostMapping(path = ["", "/"])
     fun createWorkspace(
         @GetAuthenticatedId userId: Long,
         @RequestBody createWorkspaceRequest: CreateWorkspaceRequest
@@ -31,7 +31,7 @@ class WorkspaceController(
         return workspaceService.deleteWorkspace(userId = userId, workspaceId = workspaceId)
     }
 
-    @GetMapping("/")
+    @GetMapping(path = ["", "/"])
     fun getWorkspace(
         @GetAuthenticatedId userId: Long,
     ): BaseResponse<List<WorkspaceResponse>> {
@@ -83,7 +83,7 @@ class WorkspaceController(
         )
     }
 
-    @PatchMapping("/")
+    @PatchMapping(path = ["", "/"])
     fun updateWorkspace(
         @GetAuthenticatedId userId: Long,
         @RequestBody updateWorkspaceRequest: UpdateWorkspaceRequest

--- a/src/main/kotlin/com/seugi/api/global/auth/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/seugi/api/global/auth/jwt/JwtAuthenticationFilter.kt
@@ -7,7 +7,6 @@ import com.seugi.api.global.response.BaseResponse
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
-import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.filter.OncePerRequestFilter
 
@@ -27,17 +26,7 @@ class JwtAuthenticationFilter(
             token = jwtUtils.getToken(token)
 
             when (jwtUtils.isExpired(token)) {
-                JwtErrorType.OK -> {
-                    try {
-                        val authentication: Authentication = jwtUtils.getAuthentication(token)
-
-                        SecurityContextHolder.getContext().authentication = authentication
-                    } catch (e: Exception) {
-                        setErrorResponse(response, JwtErrorCode.JWT_NULL_EXCEPTION)
-                        return
-                    }
-                }
-
+                JwtErrorType.OK -> SecurityContextHolder.getContext().authentication = jwtUtils.getAuthentication(token)
                 JwtErrorType.ExpiredJwtException -> setErrorResponse(response, JwtErrorCode.JWT_TOKEN_EXPIRED)
                 JwtErrorType.SignatureException -> setErrorResponse(response, JwtErrorCode.JWT_TOKEN_SIGNATURE_ERROR)
                 JwtErrorType.MalformedJwtException -> setErrorResponse(response, JwtErrorCode.JWT_TOKEN_ERROR)

--- a/src/main/kotlin/com/seugi/api/global/auth/jwt/JwtUtils.kt
+++ b/src/main/kotlin/com/seugi/api/global/auth/jwt/JwtUtils.kt
@@ -1,14 +1,17 @@
 package com.seugi.api.global.auth.jwt
 
+import com.seugi.api.domain.member.application.model.Member
+import com.seugi.api.global.auth.jwt.exception.type.JwtErrorType
 import io.jsonwebtoken.ExpiredJwtException
 import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.MalformedJwtException
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.stereotype.Component
-import com.seugi.api.domain.member.application.model.Member
 import java.nio.charset.StandardCharsets
+import java.security.SignatureException
 import java.util.*
 import javax.crypto.SecretKey
 import javax.crypto.spec.SecretKeySpec
@@ -28,12 +31,16 @@ class JwtUtils (
         )
     }
 
-    fun isExpired(token: String): Boolean {
+    fun isExpired(token: String): JwtErrorType {
         try {
             Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token)
-            return false
+            return JwtErrorType.OK
         } catch (e: ExpiredJwtException) {
-            return true
+            return JwtErrorType.ExpiredJwtException
+        } catch (e: SignatureException) {
+            return JwtErrorType.SignatureException
+        } catch (e: MalformedJwtException) {
+            return JwtErrorType.MalformedJwtException
         }
     }
 

--- a/src/main/kotlin/com/seugi/api/global/auth/jwt/exception/JwtErrorCode.kt
+++ b/src/main/kotlin/com/seugi/api/global/auth/jwt/exception/JwtErrorCode.kt
@@ -1,7 +1,7 @@
 package com.seugi.api.global.auth.jwt.exception
 
-import org.springframework.http.HttpStatus
 import com.seugi.api.global.exception.CustomErrorCode
+import org.springframework.http.HttpStatus
 
 enum class JwtErrorCode (
     override val status: HttpStatus,
@@ -9,8 +9,10 @@ enum class JwtErrorCode (
     override val message: String,
 ): CustomErrorCode {
 
-    JWT_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "J1", "토큰이 만료되었어요"),
-    JWT_MEMBER_NOT_MATCH(HttpStatus.UNAUTHORIZED, "J2", "비밀번호가 일치하지 않아요"),
-    JWT_NULL_EXCEPTION(HttpStatus.SERVICE_UNAVAILABLE, "J3", "알 수 없는 오류가 발생했어요"),
+    JWT_TOKEN_EXPIRED(HttpStatus.FORBIDDEN, "FORBIDDEN", "토큰이 만료되었어요"),
+    JWT_TOKEN_SIGNATURE_ERROR(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "토큰의 서명이 일치하지 않아요"),
+    JWT_TOKEN_ERROR(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "토큰이 구조가 이상하거나 데이터가 일치하지 않아요"),
+    JWT_MEMBER_NOT_MATCH(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "비밀번호가 일치하지 않아요"),
+    JWT_NULL_EXCEPTION(HttpStatus.SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", "알 수 없는 오류가 발생했어요"),
 
 }

--- a/src/main/kotlin/com/seugi/api/global/auth/jwt/exception/type/JwtErrorType.kt
+++ b/src/main/kotlin/com/seugi/api/global/auth/jwt/exception/type/JwtErrorType.kt
@@ -1,0 +1,8 @@
+package com.seugi.api.global.auth.jwt.exception.type
+
+enum class JwtErrorType {
+    OK,
+    ExpiredJwtException,
+    SignatureException,
+    MalformedJwtException,
+}


### PR DESCRIPTION
# #️⃣ 연관된 이슈

> #143 #152 

## 📝 작업 내용

JWT 인증 필터를 개선하여 JWT의 상태를 더 정확하게 판단하도록 수정되었습니다. 또한, JWT 검증 실패 시 이를 구분할 수 있는 JwtErrorType enum 클래스가 추가되었습니다. 또한, 매칭되지 않는 HTTP 상태 코드와 메시지를 더 정확하게 표현하도록 JwtErrorCode를 수정하였습니다.

## 💬 리뷰 요구사항(선택)

코드 로직중 이상한 부분이 있거나 개선사항이 있으면 말해주세요

### 📎 ETC
> 기타

🚀