### PR TITLE
Feat :: 채팅방에서 읽지 않은 메시지 개수 반환 추가

### DIFF
--- a/src/main/kotlin/com/seugi/api/domain/chat/application/service/chat/room/ChatRoomServiceImpl.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/application/service/chat/room/ChatRoomServiceImpl.kt
@@ -31,7 +31,7 @@ class ChatRoomServiceImpl(
     private val messageService: MessageService
 ) : ChatRoomService {
 
-    private fun toResponse(chatRoomEntities: List<ChatRoomEntity>): BaseResponse<List<RoomResponse>> {
+    private fun toResponse(chatRoomEntities: List<ChatRoomEntity>, userId: Long): BaseResponse<List<RoomResponse>> {
         return BaseResponse(
             status = HttpStatus.OK.value(),
             success = true,
@@ -43,7 +43,8 @@ class ChatRoomServiceImpl(
                     room = chatRoomMapper.toDomain(it),
                     members = getUserInfo(it),
                     lastMessage = lastMessageEntity?.message ?: "",
-                    lastMessageTimeStamp = (lastMessageEntity?.timestamp ?: "").toString()
+                    lastMessageTimeStamp = (lastMessageEntity?.timestamp ?: "").toString(),
+                    notReadCnt = messageService.getNotReadMessageCount(it.id.toString(), userId)
                 )
             }
         )
@@ -131,7 +132,8 @@ class ChatRoomServiceImpl(
                 room = chatRoomMapper.toDomain(data),
                 members = getUserInfo(data),
                 lastMessage = lastMessageEntity?.message ?: "",
-                lastMessageTimeStamp = (lastMessageEntity?.timestamp ?: "").toString()
+                lastMessageTimeStamp = (lastMessageEntity?.timestamp ?: "").toString(),
+                notReadCnt = messageService.getNotReadMessageCount(roomId, userId)
             )
         )
 
@@ -162,10 +164,10 @@ class ChatRoomServiceImpl(
                     }
                 }
 
-                return toResponse(rooms)
+                return toResponse(rooms, userId)
             }
 
-            GROUP -> return toResponse(chatRoomEntity)
+            GROUP -> return toResponse(chatRoomEntity, userId)
         }
     }
 
@@ -243,10 +245,10 @@ class ChatRoomServiceImpl(
                     }
                 }
 
-                return toResponse(entity)
+                return toResponse(entity, userId)
             }
 
-            GROUP -> return toResponse(chatRoomEntity)
+            GROUP -> return toResponse(chatRoomEntity, userId)
 
         }
 

--- a/src/main/kotlin/com/seugi/api/domain/chat/application/service/message/MessageService.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/application/service/message/MessageService.kt
@@ -17,6 +17,7 @@ interface MessageService {
     fun savaMessage(chatMessageDto: ChatMessageDto, userId: Long): Message
     fun getMessage(roomId: String): MessageEntity?
     fun getMessages(chatRoomId: String, userId: Long, pageable: Pageable): BaseResponse<GetMessageResponse>
+    fun getNotReadMessageCount(chatRoomId: String, userId: Long): Int
 
     fun addEmojiToMessage(userId: Long, emoji: AddEmoji): BaseResponse<Unit>
     fun deleteEmojiToMessage(userId: Long, emoji: AddEmoji): BaseResponse<Unit>

--- a/src/main/kotlin/com/seugi/api/domain/chat/application/service/message/MessageServiceImpl.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/application/service/message/MessageServiceImpl.kt
@@ -115,6 +115,10 @@ class MessageServiceImpl(
         }
     }
 
+    override fun getNotReadMessageCount(chatRoomId: String, userId: Long): Int {
+        return messageRepository.findByChatRoomIdAndRead(chatRoomId, setOf(userId)).count()
+    }
+
     @Transactional
     override fun addEmojiToMessage(userId: Long, emoji: AddEmoji): BaseResponse<Unit> {
         val id = ObjectId(emoji.messageId)

--- a/src/main/kotlin/com/seugi/api/domain/chat/domain/chat/MessageRepository.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/domain/chat/MessageRepository.kt
@@ -6,6 +6,7 @@ import org.springframework.data.mongodb.repository.MongoRepository
 
 interface MessageRepository : MongoRepository<MessageEntity, ObjectId> {
     fun findByChatRoomId(chatRoomId: String): List<MessageEntity>
+    fun findByChatRoomIdAndRead(chatRoomId: String, read: Set<Long>): List<MessageEntity>
     fun findByChatRoomIdEquals(chatRoomId: String, pageable: Pageable): List<MessageEntity>
     fun findByChatRoomIdEqualsAndReadNot(chatRoomId: String, read: Set<Long>): List<MessageEntity>
 }

--- a/src/main/kotlin/com/seugi/api/domain/chat/domain/room/mapper/RoomMapper.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/domain/room/mapper/RoomMapper.kt
@@ -55,7 +55,8 @@ class RoomMapper : Mapper<Room, ChatRoomEntity> {
         room: Room,
         members: Set<RetrieveMemberResponse>,
         lastMessage: String,
-        lastMessageTimeStamp: String
+        lastMessageTimeStamp: String,
+        notReadCnt: Int
     ): RoomResponse {
         return RoomResponse(
             id = room.id!!,
@@ -68,7 +69,8 @@ class RoomMapper : Mapper<Room, ChatRoomEntity> {
             type = room.type,
             joinUserId = members,
             lastMessage = lastMessage,
-            lastMessageTimestamp = lastMessageTimeStamp
+            lastMessageTimestamp = lastMessageTimeStamp,
+            notReadCnt = notReadCnt
         )
     }
 }

--- a/src/main/kotlin/com/seugi/api/domain/chat/presentation/chat/room/dto/response/RoomResponse.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/presentation/chat/room/dto/response/RoomResponse.kt
@@ -15,5 +15,6 @@ data class RoomResponse(
     val chatStatusEnum: ChatStatusEnum,
     val joinUserId: Set<RetrieveMemberResponse>,
     val lastMessage: String,
-    val lastMessageTimestamp: String
+    val lastMessageTimestamp: String,
+    val notReadCnt: Int
 )


### PR DESCRIPTION
# #️⃣ 연관된 이슈

> #161 

## 📝 작업 내용

채팅방에서 읽지 않은 메시지 개수를 반환하는 기능을 추가하였습니다. 이를 위해 MessageService, MessageRepository에 새로운 함수를 추가했습니다. 또한, RoomResponse, RoomMapper에 읽지 않은 메시지 개수의 필드를 추가하였습니다.

### 📎 ETC
> 기타

🚀