### PR TITLE
Fix :: 채팅방 안읽은 메시지 갯수 반환 #161

### DIFF
--- a/src/main/kotlin/com/seugi/api/domain/chat/application/service/message/MessageService.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/application/service/message/MessageService.kt
@@ -24,6 +24,6 @@ interface MessageService {
     fun deleteMessage(userId: Long, deleteMessage: DeleteMessage): BaseResponse<Unit>
 
     fun sub(userId: Long, roomId: String)
-    fun unsub(userId: Long)
+    fun unSub(userId: Long)
 
 }

--- a/src/main/kotlin/com/seugi/api/domain/chat/application/service/message/MessageServiceImpl.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/application/service/message/MessageServiceImpl.kt
@@ -227,7 +227,7 @@ class MessageServiceImpl(
     }
 
     @Transactional
-    override fun unsub(userId: Long) {
+    override fun unSub(userId: Long) {
         roomInfoRepository.deleteById(userId)
     }
 

--- a/src/main/kotlin/com/seugi/api/domain/chat/application/service/message/MessageServiceImpl.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/application/service/message/MessageServiceImpl.kt
@@ -116,7 +116,7 @@ class MessageServiceImpl(
     }
 
     override fun getNotReadMessageCount(chatRoomId: String, userId: Long): Int {
-        return messageRepository.findByChatRoomIdAndRead(chatRoomId, setOf(userId)).count()
+        return messageRepository.findByChatRoomIdEqualsAndReadNot(chatRoomId, setOf(userId)).count()
     }
 
     @Transactional

--- a/src/main/kotlin/com/seugi/api/domain/chat/domain/chat/MessageRepository.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/domain/chat/MessageRepository.kt
@@ -6,7 +6,6 @@ import org.springframework.data.mongodb.repository.MongoRepository
 
 interface MessageRepository : MongoRepository<MessageEntity, ObjectId> {
     fun findByChatRoomId(chatRoomId: String): List<MessageEntity>
-    fun findByChatRoomIdAndRead(chatRoomId: String, read: Set<Long>): List<MessageEntity>
     fun findByChatRoomIdEquals(chatRoomId: String, pageable: Pageable): List<MessageEntity>
     fun findByChatRoomIdEqualsAndReadNot(chatRoomId: String, read: Set<Long>): List<MessageEntity>
 }

--- a/src/main/kotlin/com/seugi/api/domain/chat/presentation/websocket/config/StompWebSocketConfig.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/presentation/websocket/config/StompWebSocketConfig.kt
@@ -88,7 +88,7 @@ class StompWebSocketConfig(
                         if (accessor.destination != null) {
                             val simpAttributes = SimpAttributesContextHolder.currentAttributes()
                             val userId = simpAttributes.getAttribute("user-id") as String
-                            messageService.unsub(
+                            messageService.unSub(
                                 userId = userId.toLong()
                             )
                         }


### PR DESCRIPTION
# #️⃣ 연관된 이슈

> #161 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

기존 채팅방에 안읽은 메시지 갯수 반환이 읽은 메시지 갯수 반환으로 되어있어 이점을 수정하였습니다

