### PR TITLE
Fix :: 프로필 반환 시 멤버 정보 포함

### DIFF
--- a/src/main/kotlin/com/seugi/api/domain/profile/adapter/in/response/RetrieveProfileResponse.kt
+++ b/src/main/kotlin/com/seugi/api/domain/profile/adapter/in/response/RetrieveProfileResponse.kt
@@ -1,12 +1,12 @@
 package com.seugi.api.domain.profile.adapter.`in`.response
 
+import com.seugi.api.domain.member.adapter.`in`.dto.res.RetrieveMemberResponse
 import com.seugi.api.domain.profile.application.model.Profile
 
 data class RetrieveProfileResponse (
 
-    val memberId: Long,
     val workspaceId: String, // 워크스페이스 ID
-    val picture: String,
+    val member: RetrieveMemberResponse,
     val status: String = "", // 상태메시지
     val nick: String = "", // 닉네임
     val spot: String = "", // 직위
@@ -18,9 +18,8 @@ data class RetrieveProfileResponse (
 ) {
 
     constructor (profile: Profile) : this (
-        memberId = profile.memberId.id!!.value,
         workspaceId = profile.workspaceId.value,
-        picture = profile.memberId.picture.value,
+        member = RetrieveMemberResponse(profile.memberId),
         status = profile.status.value,
         nick = profile.nick.value,
         spot = profile.spot.value,


### PR DESCRIPTION
# #️⃣ 연관된 이슈

> #174

## 📝 작업 내용

> 워크스페이스 프로필 반환 시 picture 대신 멤버를 반환하도록 바꿨습니다

### 📎 ETC
> ✅
