### PR TITLE
Feat :: 채팅방 조회 로직에 Room 종류 매개변수 추가 #178

### DIFF
--- a/src/main/kotlin/com/seugi/api/domain/chat/application/service/chat/room/ChatRoomService.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/application/service/chat/room/ChatRoomService.kt
@@ -11,7 +11,7 @@ interface ChatRoomService {
 
     fun createChatRoom(createRoomRequest: CreateRoomRequest, userId: Long, type: RoomType): BaseResponse<String>
 
-    fun getRoom(roomId: String, userId: Long): BaseResponse<RoomResponse>
+    fun getRoom(roomId: String, userId: Long, type: RoomType): BaseResponse<RoomResponse>
 
     fun getRooms(workspaceId: String, userId: Long, type: RoomType): BaseResponse<List<RoomResponse>>
 

--- a/src/main/kotlin/com/seugi/api/domain/chat/presentation/chat/room/controller/GroupChatController.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/presentation/chat/room/controller/GroupChatController.kt
@@ -48,7 +48,8 @@ class GroupChatController(
     ): BaseResponse<RoomResponse> {
         return chatRoomService.getRoom(
             roomId = roomId,
-            userId = userId
+            userId = userId,
+            type = RoomType.GROUP
         )
     }
 

--- a/src/main/kotlin/com/seugi/api/domain/chat/presentation/chat/room/controller/PersonalChatController.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/presentation/chat/room/controller/PersonalChatController.kt
@@ -50,7 +50,8 @@ class PersonalChatController(
     ): BaseResponse<RoomResponse> {
         return chatRoomService.getRoom(
             roomId = roomId,
-            userId = userId
+            userId = userId,
+            type = RoomType.PERSONAL
         )
     }
 


### PR DESCRIPTION
# #️⃣ 연관된 이슈

> #178 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

채팅방을 조회할 때, Room의 종류를 구분하여 처리하도록 로직을 변경하였습니다. RoomType을 매개변수로 받으며, 개인 채팅방과 그룹 채팅방을 구분하여 데이터를 반환합니다. 또한, 중복되는 코드를 줄이고, 메소드를 재사용하여 코드를 간결하게 만들었습니다.


### 📎 ETC
> 기타

😇
