### PR TITLE
Fix :: Get 요청시 경로가 같아 상위 로직이 실행되던 문제 해결

### DIFF
--- a/src/main/kotlin/com/seugi/api/domain/workspace/presentation/controller/WorkspaceController.kt
+++ b/src/main/kotlin/com/seugi/api/domain/workspace/presentation/controller/WorkspaceController.kt
@@ -60,7 +60,7 @@ class WorkspaceController(
         return workspaceService.getWorkspaceCode(userId = userId, workspaceId = workspaceId)
     }
 
-    @GetMapping("/{code}")
+    @GetMapping("/search/{code}")
     fun searchWorkspace(
         @PathVariable code: String,
     ): BaseResponse<WorkspaceInfoResponse> {


### PR DESCRIPTION
getWorkspace, searchWorkspace 가 동일한 주소라 상위 로직이 실행되던걸 경로를 수정하여 해결하였습니다.