### PR TITLE
Fix :: Workspace 참가전 데이터만을 가지고 조회가 되던 부분 수정

### DIFF
--- a/src/main/kotlin/com/seugi/api/domain/meal/service/MealServiceImpl.kt
+++ b/src/main/kotlin/com/seugi/api/domain/meal/service/MealServiceImpl.kt
@@ -23,7 +23,7 @@ class MealServiceImpl(
 ) : MealService {
 
     @Scheduled(cron = "0 0 0 1 * ?")
-    private fun resetAllMeal() {
+    protected fun resetAllMeal() {
         mealRepository.deleteAll()
     }
 

--- a/src/main/kotlin/com/seugi/api/domain/workspace/presentation/controller/WorkspaceController.kt
+++ b/src/main/kotlin/com/seugi/api/domain/workspace/presentation/controller/WorkspaceController.kt
@@ -125,17 +125,17 @@ class WorkspaceController(
     @GetMapping("/members/chart")
     fun getWorkspaceMemberChart(
         @GetAuthenticatedId userId: Long,
-        workspaceId: String,
+        @RequestParam workspaceId: String,
     ): BaseResponse<WorkspaceMemberChartResponse> {
-        return workspaceService.getWorkspaceMemberChart(workspaceId)
+        return workspaceService.getWorkspaceMemberChart(userId, workspaceId)
     }
 
     @GetMapping("/members")
     fun getWorkspaceMemberList(
         @GetAuthenticatedId userId: Long,
-        workspaceId: String,
+        @RequestParam workspaceId: String,
     ): BaseResponse<Set<RetrieveProfileResponse>> {
-        return workspaceService.getWorkspaceMemberList(workspaceId)
+        return workspaceService.getWorkspaceMemberList(userId, workspaceId)
     }
 
 }

--- a/src/main/kotlin/com/seugi/api/domain/workspace/service/WorkspaceService.kt
+++ b/src/main/kotlin/com/seugi/api/domain/workspace/service/WorkspaceService.kt
@@ -27,7 +27,7 @@ interface WorkspaceService {
     fun deleteWorkspace(userId: Long, workspaceId: String): BaseResponse<Unit>
     fun updateWorkspace(userId: Long, updateWorkspaceRequest: UpdateWorkspaceRequest): BaseResponse<Unit>
     fun getMyWaitList(userId: Long): BaseResponse<List<WorkspaceInfoResponse>>
-    fun getWorkspaceMemberChart(workspaceId: String): BaseResponse<WorkspaceMemberChartResponse>
-    fun getWorkspaceMemberList(workspaceId: String): BaseResponse<Set<RetrieveProfileResponse>>
+    fun getWorkspaceMemberChart(userId: Long, workspaceId: String): BaseResponse<WorkspaceMemberChartResponse>
+    fun getWorkspaceMemberList(userId: Long, workspaceId: String): BaseResponse<Set<RetrieveProfileResponse>>
 
 }

--- a/src/main/kotlin/com/seugi/api/domain/workspace/service/WorkspaceServiceImpl.kt
+++ b/src/main/kotlin/com/seugi/api/domain/workspace/service/WorkspaceServiceImpl.kt
@@ -65,9 +65,14 @@ class WorkspaceServiceImpl(
 
     @Transactional(readOnly = true)
     override fun getWorkspace(workspaceId: String, userId: Long): BaseResponse<WorkspaceResponse> {
+
+        val workspaceEntity = findWorkspaceById(workspaceId)
+
+        checkExistInWorkspace(userId, workspaceEntity)
+
         return BaseResponse(
             message = "워크스페이스 단건 조회 성공",
-            data = workspaceMapper.toWorkspaceResponse(findWorkspaceById(workspaceId))
+            data = workspaceMapper.toWorkspaceResponse(workspaceEntity)
         )
     }
 
@@ -354,10 +359,15 @@ class WorkspaceServiceImpl(
     }
 
     @Transactional(readOnly = true)
-    override fun getWorkspaceMemberChart(workspaceId: String): BaseResponse<WorkspaceMemberChartResponse> {
+    override fun getWorkspaceMemberChart(
+        userId: Long,
+        workspaceId: String,
+    ): BaseResponse<WorkspaceMemberChartResponse> {
         validateIdLength(workspaceId)
 
         val workspaceEntity: WorkspaceEntity = findWorkspaceById(workspaceId)
+
+        checkExistInWorkspace(userId, workspaceEntity)
 
         val response = WorkspaceMemberChartResponse()
 
@@ -397,10 +407,12 @@ class WorkspaceServiceImpl(
     }
 
     @Transactional(readOnly = true)
-    override fun getWorkspaceMemberList(workspaceId: String): BaseResponse<Set<RetrieveProfileResponse>> {
+    override fun getWorkspaceMemberList(userId: Long, workspaceId: String): BaseResponse<Set<RetrieveProfileResponse>> {
         validateIdLength(workspaceId)
 
         val workspaceEntity: WorkspaceEntity = findWorkspaceById(workspaceId)
+
+        checkExistInWorkspace(userId, workspaceEntity)
 
         val set = HashSet<RetrieveProfileResponse>()
 


### PR DESCRIPTION
# #️⃣ 연관된 이슈

#216 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

WorkspaceId 데이터 자체로 조회가 가능하던건 버그가 맞았습니다..;; (권한체크 로직이 없었음)
권한 체크 로직을 추가하여 Id로 데이터 조회가 안되도록 막았습니다.

## 💬 리뷰 요구사항(선택)

WorkspaceId 은닉화는 코드로 워크스페이스 참가할때 필요하여 그대로 두었습니다.
+참가시 코드 및 코드로 검색된 workspacdId 2개를 받도록 하는중이라 이 부분에 대해 의견이 있다면 남겨주세요


### 📎 ETC
> 기타

젠킨스 Webhook 이 작동 안했던데 이게 풀리퀘 후 머지 한 뒤 작동 안하면 다시 확인해봐야겠네요 😛
