### PR TITLE
Fix :: 공지 업데이트 권한체크 및 공지 반환값 수정

### DIFF
--- a/src/main/kotlin/com/seugi/api/domain/notification/domain/mapper/NotificationMapper.kt
+++ b/src/main/kotlin/com/seugi/api/domain/notification/domain/mapper/NotificationMapper.kt
@@ -47,16 +47,17 @@ class NotificationMapper : Mapper<Notification, NotificationEntity> {
         )
     }
 
-    fun transferNoticeResponse(notice: Notification): NotificationResponse {
+    fun transferNoticeResponse(notification: Notification): NotificationResponse {
         return NotificationResponse(
-            id = notice.id,
-            workspaceId = notice.workspaceId,
-            userName = notice.user.name,
-            title = notice.title,
-            content = notice.content,
-            emoji = notice.emoji,
-            creationDate = notice.creationDate.toString(),
-            lastModifiedDate = notice.lastModifiedDate.toString()
+            id = notification.id,
+            workspaceId = notification.workspaceId,
+            userId = notification.user.id,
+            userName = notification.user.name,
+            title = notification.title,
+            content = notification.content,
+            emoji = notification.emoji,
+            creationDate = notification.creationDate.toString(),
+            lastModifiedDate = notification.lastModifiedDate.toString()
         )
     }
 

--- a/src/main/kotlin/com/seugi/api/domain/notification/presentation/dto/response/NotificationResponse.kt
+++ b/src/main/kotlin/com/seugi/api/domain/notification/presentation/dto/response/NotificationResponse.kt
@@ -7,6 +7,7 @@ import com.seugi.api.domain.notification.domain.embeddable.NotificationEmoji
 data class NotificationResponse(
     val id: Long? = null,
     val workspaceId: String? = null,
+    val userId: Long? = null,
     val userName: String? = null,
     val title: String? = null,
     val content: String? = null,

--- a/src/main/kotlin/com/seugi/api/domain/notification/service/NotificationServiceImpl.kt
+++ b/src/main/kotlin/com/seugi/api/domain/notification/service/NotificationServiceImpl.kt
@@ -71,6 +71,8 @@ class NotificationServiceImpl(
     override fun updateNotice(updateNoticeRequest: UpdateNotificationRequest, userId: Long): BaseResponse<Unit> {
         val noticeEntity = findNotificationById(updateNoticeRequest.id)
 
+        if (noticeEntity.user!!.id != userId) throw CustomException(NotificationErrorCode.FORBIDDEN)
+
         noticeEntity.updateNotice(updateNoticeRequest)
 
         noticeRepository.save(noticeEntity)


### PR DESCRIPTION
# #️⃣ 연관된 이슈

>  #226

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

공지 업데이트시 권한체크 로직을 추가하였습니다.
공지 반환시 권한체크를 위한 UserId로직을 추가하였습니다.

### 📎 ETC
> 기타


