### PR TITLE
Fix :: 멤버 도메인 권한 인식 문제 & 필터 에러 응답 BaseResponse 사용

### DIFF
--- a/src/main/kotlin/com/seugi/api/global/auth/jwt/exception/ErrorResponseSender.kt
+++ b/src/main/kotlin/com/seugi/api/global/auth/jwt/exception/ErrorResponseSender.kt
@@ -2,6 +2,7 @@ package com.seugi.api.global.auth.jwt.exception
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.seugi.api.global.exception.CustomErrorCode
+import com.seugi.api.global.response.BaseResponse
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
@@ -17,7 +18,7 @@ class ErrorResponseSender (
             response.status = code.status.value()
             response.contentType = MediaType.APPLICATION_JSON_VALUE
             response.characterEncoding = "UTF-8"
-            response.writer.write(objectMapper.writeValueAsString(code))
+            response.writer.write(objectMapper.writeValueAsString(BaseResponse<Unit>(code)))
         } catch (e: IOException) {
             e.printStackTrace()
         }

--- a/src/main/kotlin/com/seugi/api/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/seugi/api/global/config/SecurityConfig.kt
@@ -42,17 +42,14 @@ class SecurityConfig (
             }
 
             .sessionManagement { session ->
-                session.sessionCreationPolicy(
-                    SessionCreationPolicy.STATELESS
-                )
+                session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             }
 
             .authorizeHttpRequests {
                 it
-                    .requestMatchers("/member/**", "/oauth2/**", "/email/**").permitAll()
-                    .requestMatchers("/member/edit", "/member/myInfo").hasRole("USER")
-                    .requestMatchers("/stomp/**").permitAll()
-                    .requestMatchers("$actuatorUrl/**").permitAll()
+                    .requestMatchers("/member/edit", "/member/myInfo").authenticated()
+                    .requestMatchers("/oauth2/**", "/email/**", "/stomp/**", "$actuatorUrl/**").permitAll()
+                    .requestMatchers("/member/**").permitAll()
                     .anyRequest().authenticated()
             }
 

--- a/src/main/kotlin/com/seugi/api/global/response/BaseResponse.kt
+++ b/src/main/kotlin/com/seugi/api/global/response/BaseResponse.kt
@@ -1,10 +1,11 @@
 package com.seugi.api.global.response
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.seugi.api.global.exception.CustomErrorCode
 import org.springframework.http.HttpStatus
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-data class BaseResponse<T> (
+data class BaseResponse<T>(
 
     val status: Int = HttpStatus.OK.value(),
     val success: Boolean = true,
@@ -12,5 +13,15 @@ data class BaseResponse<T> (
     val message: String,
     val data: T? = null
 
-)
+) {
+
+    // errorResponse constructor
+    constructor(code: CustomErrorCode) : this(
+        status = code.status.value(),
+        success = false,
+        state = code.state,
+        message = code.message
+    )
+
+}
 


### PR DESCRIPTION
# #️⃣ 연관된 이슈

> #229 
> #230 

## 📝 작업 내용

> 시큐리티에서 멤버 엔드포인트 관련 path (/member/edit, /member/info) 를 상단으로 옮겨 권한 인식 문제를 해결했고,
> CustomExceptionHandler에서 BaseResponse 사용하는 것처럼 필터단의 에러 응답도 BaseResponse를 사용하도록 수정하였습니다

### 📎 ETC
> 캘린더 기능 만들러 가겠습니다
