### PR TITLE
Fix :: 채팅방 생성 로직 개선 및 중복 체크 추가

### DIFF
--- a/src/main/kotlin/com/seugi/api/domain/chat/application/service/chat/room/ChatRoomServiceImpl.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/application/service/chat/room/ChatRoomServiceImpl.kt
@@ -27,7 +27,7 @@ class ChatRoomServiceImpl(
     private val chatRoomRepository: ChatRoomRepository,
     private val loadMemberPort: LoadMemberPort,
     private val chatRoomMapper: RoomMapper,
-    private val messageService: MessageService
+    private val messageService: MessageService,
 ) : ChatRoomService {
 
     @Transactional(readOnly = true)
@@ -54,53 +54,70 @@ class ChatRoomServiceImpl(
             .toSet()
     }
 
+    private fun validateRoomCreation(createRoomRequest: CreateRoomRequest, type: RoomType) {
+        if ((type == PERSONAL && createRoomRequest.joinUsers.size != 2) ||
+            (type == GROUP && createRoomRequest.joinUsers.size < 2)
+        ) {
+            throw CustomException(ChatErrorCode.CHAT_ROOM_CREATE_ERROR)
+        }
+    }
+
+    private fun generateRoomName(createRoomRequest: CreateRoomRequest): String {
+        return createRoomRequest.joinUsers.asSequence()
+            .map { loadMemberPort.loadMemberWithId(it).name.value }
+            .takeWhile { (createRoomRequest.roomName + it).length <= 10 }
+            .joinToString(separator = ", ")
+    }
+
     @Transactional
     override fun createChatRoom(
         createRoomRequest: CreateRoomRequest,
         userId: Long,
-        type: RoomType
+        type: RoomType,
     ): BaseResponse<String> {
 
         createRoomRequest.joinUsers.add(userId)
-
-        if (
-            type == PERSONAL && createRoomRequest.joinUsers.size > 2
-            || type == GROUP && createRoomRequest.joinUsers.size < 2
-        ) throw CustomException(
-            ChatErrorCode.CHAT_ROOM_CREATE_ERROR
+        val existingChatRoom = chatRoomRepository.findByWorkspaceIdEqualsAndJoinedUserId(
+            workspaceId = createRoomRequest.workspaceId,
+            joinedUserId = createRoomRequest.joinUsers
         )
 
-        if (type == GROUP && createRoomRequest.roomName.isEmpty()) {
-            createRoomRequest.roomName = createRoomRequest.joinUsers.asSequence()
-                .map { loadMemberPort.loadMemberWithId(it).name.value }
-                .takeWhile { (createRoomRequest.roomName + it).length <= 10 }
-                .joinToString(separator = ", ")
-        }
+        return if (existingChatRoom == null) {
+            validateRoomCreation(createRoomRequest, type)
+            if (type == GROUP && createRoomRequest.roomName.isEmpty()) {
+                createRoomRequest.roomName = generateRoomName(createRoomRequest)
+            }
 
-        val chatRoomId = chatRoomRepository.save(
-            chatRoomMapper.toEntity(
-                chatRoomMapper.toRoom(
-                    createRoomRequest = createRoomRequest,
-                    type = type,
-                    userId = userId
+            val newChatRoomId = chatRoomRepository.save(
+                chatRoomMapper.toEntity(
+                    chatRoomMapper.toRoom(
+                        createRoomRequest = createRoomRequest,
+                        type = type,
+                        userId = userId
+                    )
                 )
+            ).id.toString()
+
+            messageService.sendAndSaveMessage(
+                chatMessageDto = ChatMessageDto(
+                    type = Type.ENTER,
+                    roomId = newChatRoomId,
+                    message = "",
+                    eventList = createRoomRequest.joinUsers,
+                ),
+                userId = userId
             )
-        ).id.toString()
 
-        messageService.sendAndSaveMessage(
-            chatMessageDto = ChatMessageDto(
-                type = Type.ENTER,
-                roomId = chatRoomId,
-                message = "",
-                eventList = createRoomRequest.joinUsers,
-            ),
-            userId = userId
-        )
-
-        return BaseResponse(
-            message = "채팅방 생성 성공 | 채팅방 ID",
-            data = chatRoomId
-        )
+            BaseResponse(
+                message = "채팅방 생성 성공 | 채팅방 ID",
+                data = newChatRoomId
+            )
+        } else {
+            BaseResponse(
+                message = "채팅방 생성 성공 | 채팅방 ID",
+                data = existingChatRoom.id.toString()
+            )
+        }
     }
 
     @Transactional(readOnly = true)
@@ -209,7 +226,7 @@ class ChatRoomServiceImpl(
     override fun searchRoomNameIn(
         searchRoomRequest: SearchRoomRequest,
         type: RoomType,
-        userId: Long
+        userId: Long,
     ): BaseResponse<List<RoomResponse>> {
 
         val chatRoomEntity =

--- a/src/main/kotlin/com/seugi/api/domain/chat/domain/room/ChatRoomRepository.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/domain/room/ChatRoomRepository.kt
@@ -5,11 +5,13 @@ import com.seugi.api.domain.chat.domain.enums.type.RoomType
 import org.bson.types.ObjectId
 import org.springframework.data.mongodb.repository.MongoRepository
 
-interface ChatRoomRepository : MongoRepository<ChatRoomEntity, ObjectId>{
+interface ChatRoomRepository : MongoRepository<ChatRoomEntity, ObjectId> {
     fun findByWorkspaceIdEqualsAndChatStatusEqualsAndRoomTypeAndJoinedUserIdContains(
         workspaceId: String,
         chatStatus: ChatStatusEnum,
         roomType: RoomType,
         joinedUserId: Long
     ): MutableList<ChatRoomEntity>?
+
+    fun findByWorkspaceIdEqualsAndJoinedUserId(workspaceId: String, joinedUserId: Set<Long>): ChatRoomEntity?
 }


### PR DESCRIPTION
#240 

동일 워크스페이스에서 중복된 채팅방 생성 방지 로직을 추가했습니다. 요청 시 회원 수를 검증하고, 그룹 채팅방 이름을 자동 생성합니다. 함수로 로직을 분리하였습니다.