### PR TITLE
Fix :: 사용자 워크스페이스 권한 확인 로직 수정

### DIFF
--- a/src/main/kotlin/com/seugi/api/domain/timetable/service/TimetableServiceImpl.kt
+++ b/src/main/kotlin/com/seugi/api/domain/timetable/service/TimetableServiceImpl.kt
@@ -33,9 +33,9 @@ class TimetableServiceImpl(
     }
 
     private fun checkUserInWorkspace(workspaceEntity: WorkspaceEntity, userId: Long) {
-        if (workspaceEntity.workspaceAdmin != userId ||
-            !workspaceEntity.middleAdmin.contains(userId) ||
-            !workspaceEntity.teacher.contains(userId) ||
+        if (workspaceEntity.workspaceAdmin != userId &&
+            !workspaceEntity.middleAdmin.contains(userId) &&
+            !workspaceEntity.teacher.contains(userId) &&
             !workspaceEntity.student.contains(userId)
         ) throw CustomException(TimetableException.FORBIDDEN)
     }


### PR DESCRIPTION
사용자가 워크스페이스 권한이 있는지 확인하는 로직에서 OR 조건을 AND 조건으로 수정했습니다. 이로 인해 워크스페이스에 포함된 사용자를 정확히 식별할 수 있습니다.
