### PR TITLE
Fix :: Profile 도메인 Mapper #toEntity nick 필드 수정

### DIFF
--- a/src/main/kotlin/com/seugi/api/domain/profile/adapter/out/mapper/ProfileMapper.kt
+++ b/src/main/kotlin/com/seugi/api/domain/profile/adapter/out/mapper/ProfileMapper.kt
@@ -40,7 +40,7 @@ class ProfileMapper (
             schGrade = domain.schGrade.value,
             schClass = domain.schClass.value,
             schNumber = domain.schNumber.value,
-            nick = domain.location.value,
+            nick = domain.nick.value,
             phone = domain.phone.value,
             spot = domain.spot.value,
             status = domain.status.value,

--- a/src/main/kotlin/com/seugi/api/global/infra/discord/webhook/DiscordClient.kt
+++ b/src/main/kotlin/com/seugi/api/global/infra/discord/webhook/DiscordClient.kt
@@ -4,7 +4,6 @@ import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 
-
 @FeignClient(name = "discord-client", url = "\${discord.webhook.url}")
 interface DiscordClient {
     @PostMapping


### PR DESCRIPTION
# #️⃣ 연관된 이슈

> #260 

## 📝 작업 내용

> 프로필 Mapper#toEntity의 nick 필드가 location을 참조하는 것을 nick으로 수정하였습니다.

### 📎 ETC
> 🔨
