### PR TITLE
Refactor :: 메시지 페이징에서 타임스탬프 기반 조회로 변경 #277

### DIFF
--- a/src/main/kotlin/com/seugi/api/domain/chat/application/service/message/MessageService.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/application/service/message/MessageService.kt
@@ -8,14 +8,14 @@ import com.seugi.api.domain.chat.presentation.chat.member.dto.response.GetMessag
 import com.seugi.api.domain.chat.presentation.websocket.dto.ChatMessageDto
 import com.seugi.api.domain.chat.presentation.websocket.dto.MessageEventDto
 import com.seugi.api.global.response.BaseResponse
-import org.springframework.data.domain.Pageable
+import java.time.LocalDateTime
 
 interface MessageService {
 
     fun sendAndSaveMessage(chatMessageDto: ChatMessageDto, userId: Long)
     fun sendEventMessage(message: MessageEventDto, roomId: String)
     fun getMessage(roomId: String): MessageEntity?
-    fun getMessages(chatRoomId: String, userId: Long, pageable: Pageable): BaseResponse<GetMessageResponse>
+    fun getMessages(chatRoomId: String, userId: Long, timestamp: LocalDateTime): BaseResponse<GetMessageResponse>
     fun getNotReadMessageCount(chatRoom: ChatRoomEntity, userId: Long): Int
 
     fun addEmojiToMessage(userId: Long, emoji: AddEmoji): BaseResponse<Unit>

--- a/src/main/kotlin/com/seugi/api/domain/chat/application/service/message/MessageServiceImpl.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/application/service/message/MessageServiceImpl.kt
@@ -19,7 +19,6 @@ import com.seugi.api.global.infra.fcm.FCMService
 import com.seugi.api.global.response.BaseResponse
 import org.bson.types.ObjectId
 import org.springframework.amqp.rabbit.core.RabbitTemplate
-import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
@@ -79,10 +78,15 @@ class MessageServiceImpl(
 
 
     @Transactional(readOnly = true)
-    override fun getMessages(chatRoomId: String, userId: Long, pageable: Pageable): BaseResponse<GetMessageResponse> {
+    override fun getMessages(
+        chatRoomId: String,
+        userId: Long,
+        timestamp: LocalDateTime,
+    ): BaseResponse<GetMessageResponse> {
 
         val allMessages =
-            messageRepository.findByChatRoomIdEquals(chatRoomId, pageable).map { messageMapper.toDomain(it) }
+            messageRepository.findTop30ByChatRoomIdEqualsAndTimestampBefore(chatRoomId, timestamp)
+                .map { messageMapper.toDomain(it) }
 
             return BaseResponse(
                 message = "채팅 불러오기 성공",

--- a/src/main/kotlin/com/seugi/api/domain/chat/domain/chat/MessageRepository.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/domain/chat/MessageRepository.kt
@@ -1,12 +1,11 @@
 package com.seugi.api.domain.chat.domain.chat
 
 import org.bson.types.ObjectId
-import org.springframework.data.domain.Pageable
 import org.springframework.data.mongodb.repository.MongoRepository
 import java.time.LocalDateTime
 
 interface MessageRepository : MongoRepository<MessageEntity, ObjectId> {
     fun findByChatRoomId(chatRoomId: String): List<MessageEntity>
-    fun findByChatRoomIdEquals(chatRoomId: String, pageable: Pageable): List<MessageEntity>
     fun findByChatRoomIdEqualsAndTimestampBefore(chatRoomId: String, timestamp: LocalDateTime): List<MessageEntity>
+    fun findTop30ByChatRoomIdEqualsAndTimestampBefore(chatRoomId: String, timestamp: LocalDateTime): List<MessageEntity>
 }

--- a/src/main/kotlin/com/seugi/api/domain/chat/presentation/message/controller/MessageController.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/presentation/message/controller/MessageController.kt
@@ -6,10 +6,8 @@ import com.seugi.api.domain.chat.domain.chat.embeddable.DeleteMessage
 import com.seugi.api.domain.chat.presentation.chat.member.dto.response.GetMessageResponse
 import com.seugi.api.global.common.annotation.GetAuthenticatedId
 import com.seugi.api.global.response.BaseResponse
-import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Sort
-import org.springframework.data.web.PageableDefault
 import org.springframework.web.bind.annotation.*
+import java.time.LocalDateTime
 
 /**
  * 메시지 삭제, 이모지 달기, 읽음표시
@@ -58,12 +56,12 @@ class MessageController(
     fun getMessages(
         @GetAuthenticatedId userId: Long,
         @PathVariable roomId: String,
-        @PageableDefault(sort = ["id"], direction = Sort.Direction.DESC, size = 20) pageable: Pageable
+        @RequestParam("timestamp", required = false) timestamp: LocalDateTime = LocalDateTime.now(),
     ): BaseResponse<GetMessageResponse> {
         return messageService.getMessages(
             chatRoomId = roomId,
             userId = userId,
-            pageable = pageable
+            timestamp = timestamp
         )
     }
 


### PR DESCRIPTION
# #️⃣ 연관된 이슈

> #277 

## 📝 작업 내용

서비스와 컨트롤러에서 Pageable 대신 타임스탬프를 사용해 메시지를 조회하도록 수정. 
이제 최근 메시지를 타임스탬프 기준으로 가져옵니다.

### 📎 ETC

🤣
