### PR TITLE
Fix :: ChatRoom, Socket 수정

### DIFF
--- a/src/main/kotlin/com/seugi/api/domain/chat/application/service/chat/room/ChatRoomServiceImpl.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/application/service/chat/room/ChatRoomServiceImpl.kt
@@ -60,6 +60,7 @@ class ChatRoomServiceImpl(
 
         val chatRoom = findChatRoomById(roomId)
         chatRoom.joinedUserInfo.find { it.userId == userId }?.timestamp = DateTimeUtil.localDateTime
+        chatRoomRepository.save(chatRoom).joinedUserInfo.find { it.userId == userId }?.timestamp
     }
 
     @Transactional
@@ -69,6 +70,7 @@ class ChatRoomServiceImpl(
 
         val chatRoom = findChatRoomById(roomId)
         chatRoom.joinedUserInfo.find { it.userId == userId }?.timestamp = LocalDateTime.now()
+        chatRoomRepository.save(chatRoom).joinedUserInfo.find { it.userId == userId }?.timestamp
     }
 
     private fun toResponse(chatRoomEntity: ChatRoomEntity, userId: Long): RoomResponse {


### PR DESCRIPTION
# #️⃣ 연관된 이슈

#286 

## 📝 작업 내용

ChatRoom에 유저 정보를 업데이트한 후 저장하도록 수정했습니다. WebSocket 연결, 구독, 연결 해제를 간소화하는 리팩토링 수행
문제는 when 키워드에서 위에 작업이 아래로 전수되면서 로직이 작동하는게 문제였음 그래서 필요한 로직만 수행하도록 변경

### 📎 ETC
> 기타

🥲