### PR TITLE
Feature :: Workspace 가입시 FCM 호출 구현 #323

### DIFF
--- a/src/main/kotlin/com/seugi/api/domain/notification/service/NotificationServiceImpl.kt
+++ b/src/main/kotlin/com/seugi/api/domain/notification/service/NotificationServiceImpl.kt
@@ -39,7 +39,7 @@ class NotificationServiceImpl(
     }
 
     private fun sendAlert(workspaceId: String, userId: Long, message: String) {
-        fcmService.sendAlert(workspaceId, userId, message)
+        fcmService.sendNotificationAlert(workspaceId, userId, message)
     }
 
     @Transactional

--- a/src/main/kotlin/com/seugi/api/domain/workspace/service/WorkspaceServiceImpl.kt
+++ b/src/main/kotlin/com/seugi/api/domain/workspace/service/WorkspaceServiceImpl.kt
@@ -16,6 +16,7 @@ import com.seugi.api.domain.workspace.presentation.dto.response.WorkspaceInfoRes
 import com.seugi.api.domain.workspace.presentation.dto.response.WorkspaceMemberChartResponse
 import com.seugi.api.domain.workspace.presentation.dto.response.WorkspaceResponse
 import com.seugi.api.global.exception.CustomException
+import com.seugi.api.global.infra.fcm.FCMService
 import com.seugi.api.global.infra.nice.school.NiceSchoolService
 import com.seugi.api.global.response.BaseResponse
 import org.bson.types.ObjectId
@@ -34,6 +35,7 @@ class WorkspaceServiceImpl(
     private val loadProfilePort: LoadProfilePort,
     private val loadMemberPort: LoadMemberPort,
     private val niceSchoolService: NiceSchoolService,
+    private val fcmService: FCMService,
 ) : WorkspaceService {
 
     private fun genCode(length: Int = 6): String {
@@ -286,6 +288,8 @@ class WorkspaceServiceImpl(
         val workspaceEntity: WorkspaceEntity = findWorkspaceById(waitSetWorkspaceMemberRequest.workspaceId)
 
         checkForStudent(workspaceEntity = workspaceEntity, userId = userId)
+
+        fcmService.sendJoinWorkspaceAlert(waitSetWorkspaceMemberRequest.userSet, workspaceEntity)
 
         when (waitSetWorkspaceMemberRequest.role) {
             WorkspaceRole.STUDENT -> {

--- a/src/main/kotlin/com/seugi/api/global/infra/fcm/FCMService.kt
+++ b/src/main/kotlin/com/seugi/api/global/infra/fcm/FCMService.kt
@@ -55,7 +55,7 @@ class FCMService(
         tokens.forEach { token ->
             FirebaseMessaging.getInstance().sendAsync(
                 Message.builder()
-                    .setToken(token)
+                    .setToken(token.ifEmpty { return })
                     .setNotification(notification)
                     .build()
             )

--- a/src/main/kotlin/com/seugi/api/global/infra/fcm/FCMService.kt
+++ b/src/main/kotlin/com/seugi/api/global/infra/fcm/FCMService.kt
@@ -8,6 +8,7 @@ import com.seugi.api.domain.chat.domain.room.ChatRoomRepository
 import com.seugi.api.domain.chat.exception.ChatErrorCode
 import com.seugi.api.domain.member.application.model.Member
 import com.seugi.api.domain.member.application.port.out.LoadMemberPort
+import com.seugi.api.domain.workspace.domain.entity.WorkspaceEntity
 import com.seugi.api.domain.workspace.service.WorkspaceService
 import com.seugi.api.global.exception.CustomException
 import com.seugi.api.global.util.DateTimeUtil
@@ -46,7 +47,7 @@ class FCMService(
         return Notification.builder()
             .setTitle(title)
             .setBody(body)
-            .setImage(imageUrl)
+            .setImage(imageUrl ?: icon)
             .build()
     }
 
@@ -88,7 +89,7 @@ class FCMService(
         }
     }
 
-    fun sendAlert(workspaceId: String, userId: Long, message: String) {
+    fun sendNotificationAlert(workspaceId: String, userId: Long, message: String) {
         val workspace = workspaceService.findWorkspaceById(workspaceId)
         val sendUser = getMember(userId)
         val users = workspace.student + workspace.middleAdmin + workspace.workspaceAdmin - userId
@@ -103,6 +104,19 @@ class FCMService(
             sendFCMNotifications(getMember(it!!).getFCMToken(), notification)
         }
 
+    }
+
+    fun sendJoinWorkspaceAlert(users: Set<Long>, workspaceEntity: WorkspaceEntity) {
+
+        val notification = buildNotification(
+            title = "${workspaceEntity.workspaceName}",
+            body = "워크스페이스 가입이 승인되었습니다.",
+            imageUrl = workspaceEntity.workspaceImageUrl
+        )
+
+        users.forEach {
+            sendFCMNotifications(getMember(it).getFCMToken(), notification)
+        }
     }
 
 }


### PR DESCRIPTION
# #️⃣ 연관된 이슈

> #323 

## 📝 작업 내용

기존 워크스페이스 가입시 FCM 알림을 보내지 않아 유저가 알수 있는 방법이 직접 들어오는 것 밖에 없었는데 로직을 추가해 알 수 있도록 구현함
++ 추가적으로 토큰 빈값이 오류가 발생하였는데 검증문을 통해 문제를 방지

### 📎 ETC
> 기타

🚀