### PR TITLE
Feature :: 소켓 애러 핸들링 #333

### DIFF
--- a/src/main/kotlin/com/seugi/api/domain/chat/presentation/websocket/config/StompWebSocketConfig.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/presentation/websocket/config/StompWebSocketConfig.kt
@@ -1,8 +1,8 @@
 package com.seugi.api.domain.chat.presentation.websocket.config
 
 import com.seugi.api.domain.chat.application.service.chat.room.ChatRoomService
+import com.seugi.api.domain.chat.presentation.websocket.util.SecurityUtils
 import com.seugi.api.domain.member.application.exception.MemberErrorCode
-import com.seugi.api.global.auth.jwt.JwtUserDetails
 import com.seugi.api.global.auth.jwt.JwtUtils
 import com.seugi.api.global.exception.CustomException
 import org.springframework.beans.factory.annotation.Value
@@ -15,7 +15,6 @@ import org.springframework.messaging.simp.config.ChannelRegistration
 import org.springframework.messaging.simp.config.MessageBrokerRegistry
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor
 import org.springframework.messaging.support.ChannelInterceptor
-import org.springframework.messaging.support.MessageBuilder
 import org.springframework.messaging.support.MessageHeaderAccessor
 import org.springframework.util.AntPathMatcher
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker
@@ -50,9 +49,9 @@ class StompWebSocketConfig(
                 val accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor::class.java)!!
 
                 when (accessor.messageType) {
-                    SimpMessageType.CONNECT -> handleConnect(message, accessor)
+                    SimpMessageType.CONNECT -> handleConnect(accessor)
                     SimpMessageType.SUBSCRIBE -> handleSubscribe(accessor)
-                    SimpMessageType.UNSUBSCRIBE, SimpMessageType.DISCONNECT -> handleUnsubscribeOrDisconnect()
+                    SimpMessageType.UNSUBSCRIBE, SimpMessageType.DISCONNECT -> handleUnsubscribeOrDisconnect(accessor)
                     else -> {}
                 }
                 return message
@@ -60,20 +59,13 @@ class StompWebSocketConfig(
         })
     }
 
-    private fun handleConnect(message: Message<*>, accessor: StompHeaderAccessor) {
+    private fun handleConnect(accessor: StompHeaderAccessor) {
         val authToken = accessor.getNativeHeader("Authorization")?.firstOrNull()
         if (authToken != null && authToken.startsWith("Bearer ")) {
             val auth = jwtUtils.getAuthentication(authToken)
-            val userDetails = auth.principal as? JwtUserDetails
-            val userId: String? = userDetails?.id?.value?.toString()
-
-            if (userId != null) {
-                val simpAttributes = SimpAttributesContextHolder.currentAttributes()
-                simpAttributes.setAttribute("user-id", userId)
-                MessageBuilder.createMessage(message.payload, accessor.messageHeaders)
-            } else {
-                throw CustomException(MemberErrorCode.MEMBER_NOT_FOUND)
-            }
+            accessor.user = auth
+        } else {
+            throw CustomException(MemberErrorCode.MEMBER_NOT_FOUND)
         }
     }
 
@@ -81,25 +73,20 @@ class StompWebSocketConfig(
         accessor.destination?.let {
             val simpAttributes = SimpAttributesContextHolder.currentAttributes()
             simpAttributes.setAttribute("sub", it.substringAfterLast("."))
-            val userId = simpAttributes.getAttribute("user-id") as String
             chatRoomService.sub(
-                userId = userId.toLong(),
+                userId = SecurityUtils.getUserId(accessor.user),
                 roomId = it.substringAfterLast(".")
             )
         }
     }
 
-    private fun handleUnsubscribeOrDisconnect() {
-        val simpAttributes = SimpAttributesContextHolder.currentAttributes()
-        val userId = simpAttributes.getAttribute("user-id") as String?
-        val roomId = simpAttributes.getAttribute("sub") as String?
-        userId?.let {
-            roomId?.let {
-                chatRoomService.unSub(
-                    userId = userId.toLong(),
-                    roomId = it
-                )
-            }
+    private fun handleUnsubscribeOrDisconnect(accessor: StompHeaderAccessor) {
+        accessor.destination?.let {
+            val simpAttributes = SimpAttributesContextHolder.currentAttributes()
+            chatRoomService.unSub(
+                userId = SecurityUtils.getUserId(accessor.user),
+                roomId = simpAttributes.getAttribute("sub").toString()
+            )
         }
     }
 }

--- a/src/main/kotlin/com/seugi/api/domain/chat/presentation/websocket/controller/StompRabbitMQController.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/presentation/websocket/controller/StompRabbitMQController.kt
@@ -2,21 +2,20 @@ package com.seugi.api.domain.chat.presentation.websocket.controller
 
 import com.seugi.api.domain.chat.application.service.message.MessageService
 import com.seugi.api.domain.chat.presentation.websocket.dto.ChatMessageDto
+import com.seugi.api.domain.chat.presentation.websocket.util.SecurityUtils
 import org.springframework.messaging.handler.annotation.MessageMapping
-import org.springframework.messaging.simp.SimpAttributesContextHolder
 import org.springframework.stereotype.Controller
+import java.security.Principal
 
 
 @Controller
 class StompRabbitMQController(
-    private val messageService: MessageService
+    private val messageService: MessageService,
 ) {
 
     @MessageMapping("chat.message")
-    fun send(chat: ChatMessageDto) {
-        val simpAttributes = SimpAttributesContextHolder.currentAttributes()
-        val userId = simpAttributes.getAttribute("user-id") as String?
-        messageService.sendAndSaveMessage(chat, userId!!.toLong())
+    fun send(chat: ChatMessageDto, principal: Principal) {
+        messageService.sendAndSaveMessage(chat, SecurityUtils.getUserId(principal))
     }
 
 }

--- a/src/main/kotlin/com/seugi/api/domain/chat/presentation/websocket/handler/StompErrorHandler.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/presentation/websocket/handler/StompErrorHandler.kt
@@ -1,0 +1,61 @@
+package com.seugi.api.domain.chat.presentation.websocket.handler
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.seugi.api.global.response.ErrorResponse
+import io.jsonwebtoken.ExpiredJwtException
+import io.jsonwebtoken.MalformedJwtException
+import io.jsonwebtoken.UnsupportedJwtException
+import org.springframework.context.annotation.Configuration
+import org.springframework.messaging.Message
+import org.springframework.messaging.MessageDeliveryException
+import org.springframework.messaging.simp.stomp.StompCommand
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor
+import org.springframework.messaging.support.MessageBuilder
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler
+import java.nio.charset.StandardCharsets
+import java.security.SignatureException
+
+@Configuration
+class StompErrorHandler(private val objectMapper: ObjectMapper) : StompSubProtocolErrorHandler() {
+
+    override fun handleClientMessageProcessingError(clientMessage: Message<ByteArray>?, ex: Throwable): Message<ByteArray>? {
+
+        return when (ex) {
+            is MessageDeliveryException -> {
+                when (val cause = ex.cause) {
+                    is AccessDeniedException -> {
+                        sendErrorMessage(ErrorResponse(status = 4403, message = "Access denied"))
+                    }
+                    else -> {
+                        if (isJwtException(cause)) {
+                            sendErrorMessage(ErrorResponse(status = 4403, message = cause?.message ?: "JWT Exception"))
+                        } else {
+                            sendErrorMessage(ErrorResponse(status = 4403, message = cause?.stackTraceToString() ?: "Unhandled exception"))
+                        }
+                    }
+                }
+            }
+            else -> {
+                sendErrorMessage(ErrorResponse(status = 4400, message = ex.message ?: "Unhandled root exception"))
+            }
+        }
+    }
+
+    private fun isJwtException(ex: Throwable?): Boolean {
+        return ex is SignatureException || ex is ExpiredJwtException || ex is MalformedJwtException || ex is UnsupportedJwtException || ex is IllegalArgumentException
+    }
+
+    private fun sendErrorMessage(errorResponse: ErrorResponse): Message<ByteArray> {
+        val headers = StompHeaderAccessor.create(StompCommand.ERROR).apply {
+            message = errorResponse.message
+        }
+        return try {
+            val json = objectMapper.writeValueAsString(errorResponse)
+            MessageBuilder.createMessage(json.toByteArray(StandardCharsets.UTF_8), headers.messageHeaders)
+        } catch (e: JsonProcessingException) {
+            MessageBuilder.createMessage(errorResponse.message.toByteArray(StandardCharsets.UTF_8), headers.messageHeaders)
+        }
+    }
+}

--- a/src/main/kotlin/com/seugi/api/domain/chat/presentation/websocket/util/SecurityUtils.kt
+++ b/src/main/kotlin/com/seugi/api/domain/chat/presentation/websocket/util/SecurityUtils.kt
@@ -1,0 +1,13 @@
+package com.seugi.api.domain.chat.presentation.websocket.util
+
+import com.seugi.api.global.auth.jwt.JwtUserDetails
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import java.security.Principal
+
+object SecurityUtils {
+
+    fun getUserId(principal: Principal?): Long {
+        return (principal as? UsernamePasswordAuthenticationToken)?.principal.let { it as? JwtUserDetails }?.member?.id?.value
+            ?: -1
+    }
+}

--- a/src/main/kotlin/com/seugi/api/global/config/RabbitMQConfig.kt
+++ b/src/main/kotlin/com/seugi/api/global/config/RabbitMQConfig.kt
@@ -1,4 +1,4 @@
-package com.seugi.api.domain.chat.presentation.websocket.config
+package com.seugi.api.global.config
 
 import org.springframework.amqp.core.BindingBuilder
 import org.springframework.amqp.core.Queue

--- a/src/main/kotlin/com/seugi/api/global/exception/CustomSocketExceptionHandler.kt
+++ b/src/main/kotlin/com/seugi/api/global/exception/CustomSocketExceptionHandler.kt
@@ -1,0 +1,46 @@
+package com.seugi.api.global.exception
+
+import com.seugi.api.global.response.ErrorResponse
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler
+import org.springframework.messaging.simp.SimpAttributesContextHolder
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.web.bind.annotation.ControllerAdvice
+import java.net.SocketException
+import java.security.Principal
+
+@ControllerAdvice
+class CustomSocketExceptionHandler(
+//    private val template: RabbitMessagingTemplate
+    private val template: SimpMessagingTemplate,
+) {
+
+    @MessageExceptionHandler(SocketException::class)
+    fun handleSocketException(principal: Principal, ex: Exception) {
+        template.convertAndSendToUser(
+            principal.name,
+            "/error",
+            ErrorResponse(status = 4500, message = ex.cause?.message ?: "Socket Error")
+        )
+    }
+
+    @MessageExceptionHandler(RuntimeException::class)
+    fun handleRuntimeException(principal: Principal, ex: Exception) {
+        val simpAttributes = SimpAttributesContextHolder.currentAttributes()
+        println(
+            principal.name + " | " + simpAttributes.getAttribute("sub").toString() + " | " + simpAttributes.sessionId
+        )
+        template.convertAndSendToUser(
+            principal.name,
+            "/queue/errors",
+            ErrorResponse(status = 4500, message = ex.cause?.message ?: "Socket Error")
+        )
+    }
+
+//    @Throws(IOException::class)
+//    private fun removeSession(message: Message<*>) {
+//        val stompHeaderAccessor = StompHeaderAccessor.wrap(message)
+//        val sessionId = stompHeaderAccessor.sessionId
+//    }
+
+
+}

--- a/src/main/kotlin/com/seugi/api/global/exception/CustomSocketExceptionHandler.kt
+++ b/src/main/kotlin/com/seugi/api/global/exception/CustomSocketExceptionHandler.kt
@@ -2,45 +2,46 @@ package com.seugi.api.global.exception
 
 import com.seugi.api.global.response.ErrorResponse
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler
-import org.springframework.messaging.simp.SimpAttributesContextHolder
+import org.springframework.messaging.Message
 import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor
 import org.springframework.web.bind.annotation.ControllerAdvice
+import java.io.IOException
 import java.net.SocketException
 import java.security.Principal
 
 @ControllerAdvice
 class CustomSocketExceptionHandler(
-//    private val template: RabbitMessagingTemplate
-    private val template: SimpMessagingTemplate,
+    private val template: SimpMessagingTemplate
 ) {
 
+    private val bindingUrl = "/queue/errors"
+
     @MessageExceptionHandler(SocketException::class)
-    fun handleSocketException(principal: Principal, ex: Exception) {
+    fun handleSocketException(message: Message<*>, principal: Principal, ex: Exception) {
+        removeSession(message)
         template.convertAndSendToUser(
             principal.name,
-            "/error",
+            bindingUrl,
             ErrorResponse(status = 4500, message = ex.cause?.message ?: "Socket Error")
         )
     }
 
     @MessageExceptionHandler(RuntimeException::class)
     fun handleRuntimeException(principal: Principal, ex: Exception) {
-        val simpAttributes = SimpAttributesContextHolder.currentAttributes()
-        println(
-            principal.name + " | " + simpAttributes.getAttribute("sub").toString() + " | " + simpAttributes.sessionId
-        )
         template.convertAndSendToUser(
             principal.name,
-            "/queue/errors",
-            ErrorResponse(status = 4500, message = ex.cause?.message ?: "Socket Error")
+            bindingUrl,
+            ErrorResponse(status = 4500, message = ex.cause?.stackTraceToString() ?: "Socket Error")
         )
     }
 
-//    @Throws(IOException::class)
-//    private fun removeSession(message: Message<*>) {
-//        val stompHeaderAccessor = StompHeaderAccessor.wrap(message)
-//        val sessionId = stompHeaderAccessor.sessionId
-//    }
+    @Throws(IOException::class)
+    private fun removeSession(message: Message<*>) {
+        val stompHeaderAccessor = StompHeaderAccessor.wrap(message)
+        val sessionId = stompHeaderAccessor.sessionId
+        stompHeaderAccessor.sessionAttributes?.remove(sessionId)
+    }
 
 
 }

--- a/src/main/kotlin/com/seugi/api/global/response/BaseResponse.kt
+++ b/src/main/kotlin/com/seugi/api/global/response/BaseResponse.kt
@@ -7,13 +7,13 @@ import org.springframework.http.HttpStatus
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class BaseResponse<T>(
 
-    val status: Int = HttpStatus.OK.value(),
-    val success: Boolean = true,
-    val state: String? = "OK",
-    val message: String,
-    val data: T? = null
+    override val status: Int = HttpStatus.OK.value(),
+    override val success: Boolean = true,
+    override val state: String = "OK",
+    override val message: String,
+    val data: T? = null,
 
-) {
+    ) : ResponseInterface {
 
     // errorResponse constructor
     constructor(code: CustomErrorCode) : this(

--- a/src/main/kotlin/com/seugi/api/global/response/ErrorResponse.kt
+++ b/src/main/kotlin/com/seugi/api/global/response/ErrorResponse.kt
@@ -1,0 +1,11 @@
+package com.seugi.api.global.response
+
+import com.fasterxml.jackson.annotation.JsonInclude
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class ErrorResponse(
+    override val status: Int = 1000,
+    override val success: Boolean = false,
+    override val state: String = "Error",
+    override val message: String,
+) : ResponseInterface

--- a/src/main/kotlin/com/seugi/api/global/response/ErrorResponse.kt
+++ b/src/main/kotlin/com/seugi/api/global/response/ErrorResponse.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class ErrorResponse(
-    override val status: Int = 1000,
+    override val status: Int = 4500,
     override val success: Boolean = false,
     override val state: String = "Error",
     override val message: String,

--- a/src/main/kotlin/com/seugi/api/global/response/ResponseInterface.kt
+++ b/src/main/kotlin/com/seugi/api/global/response/ResponseInterface.kt
@@ -1,0 +1,8 @@
+package com.seugi.api.global.response
+
+interface ResponseInterface {
+    val status: Int
+    val success: Boolean
+    val state: String
+    val message: String
+}


### PR DESCRIPTION
# #️⃣ 연관된 이슈

> #333 

## 📝 작업 내용

기존 소캣 로직 동작과정에서
오류 발생시 모두 소켓이 close 되는 상황이 있었습니다. 이를 소켓 핸들링을 통해 오류 메시지를 반환하게 했으며
비즈니스 오류시엔 소켓 연결이 안 끊어지도록 만들었습니다.

추가적으로 기존 해더에 유저 정보를 넘기는 방식으로 유저인증 기반을 사용하였지만 simp 기반의 시큐리티 기반으로 변경하였습니다.

관련사항 문서 확인 부탁드립니다.

### 📎 ETC
> 기타

King is back 🚀
