### PR TITLE
Refactor :: 학사일정 API 응답속도 개선작업 #346

### DIFF
--- a/src/main/kotlin/com/seugi/api/SeugiServerApplication.kt
+++ b/src/main/kotlin/com/seugi/api/SeugiServerApplication.kt
@@ -3,9 +3,11 @@ package com.seugi.api
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
+import org.springframework.cache.annotation.EnableCaching
 import org.springframework.cloud.openfeign.EnableFeignClients
 import org.springframework.scheduling.annotation.EnableScheduling
 
+@EnableCaching
 @EnableScheduling
 @EnableFeignClients
 @SpringBootApplication

--- a/src/main/kotlin/com/seugi/api/domain/schedule/domain/ScheduleEntity.kt
+++ b/src/main/kotlin/com/seugi/api/domain/schedule/domain/ScheduleEntity.kt
@@ -22,6 +22,6 @@ class ScheduleEntity(
     val eventContent: String,
 
     @ElementCollection
-    val grade: List<Int>,
+    val grade: Set<Int>,
 
     )

--- a/src/main/kotlin/com/seugi/api/domain/schedule/domain/ScheduleRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/seugi/api/domain/schedule/domain/ScheduleRepositoryCustomImpl.kt
@@ -21,6 +21,7 @@ class ScheduleRepositoryCustomImpl(
         val scheduleEntity = QScheduleEntity.scheduleEntity
         return jpaQueryFactory
             .selectFrom(scheduleEntity)
+            .leftJoin(scheduleEntity.grade).fetchJoin()
             .where(scheduleEntity.workspaceId.eq(workspaceId))
             .fetch() ?: emptyList()
     }
@@ -29,6 +30,7 @@ class ScheduleRepositoryCustomImpl(
         val scheduleEntity = QScheduleEntity.scheduleEntity
         return jpaQueryFactory
             .selectFrom(scheduleEntity)
+            .leftJoin(scheduleEntity.grade).fetchJoin()
             .where(scheduleEntity.date.substring(5, 7).eq(month.toString()), scheduleEntity.workspaceId.eq(workspaceId))
             .fetch() ?: emptyList()
     }

--- a/src/main/kotlin/com/seugi/api/domain/schedule/domain/mapper/ScheduleMapper.kt
+++ b/src/main/kotlin/com/seugi/api/domain/schedule/domain/mapper/ScheduleMapper.kt
@@ -27,13 +27,13 @@ class ScheduleMapper : Mapper<Schedule, ScheduleEntity> {
             date = domain.date!!,
             eventName = domain.eventName ?: "",
             eventContent = domain.eventContent ?: "",
-            grade = domain.grade ?: emptyList()
+            grade = domain.grade ?: emptySet()
         )
     }
 
     fun toDomain(row: List<ScheduleRow>, workspaceId: String): List<Schedule> {
         return row.map { scheduleRow ->
-            val grade = listOfNotNull(
+            val grade = setOfNotNull(
                 scheduleRow.oneGradeEventYn.takeIf { it == "Y" }?.let { 1 },
                 scheduleRow.twGradeEventYn.takeIf { it == "Y" }?.let { 2 },
                 scheduleRow.threeGradeEventYn.takeIf { it == "Y" }?.let { 3 },

--- a/src/main/kotlin/com/seugi/api/domain/schedule/domain/model/Schedule.kt
+++ b/src/main/kotlin/com/seugi/api/domain/schedule/domain/model/Schedule.kt
@@ -6,5 +6,5 @@ data class Schedule(
     val date: String? = null,
     val eventName: String? = null,
     val eventContent: String? = null,
-    val grade: List<Int>? = null,
+    val grade: Set<Int>? = null,
 )


### PR DESCRIPTION
# #️⃣ 연관된 이슈

> #346

## 📝 작업 내용

기존 학사일정 조회시 N+1 문제 발생하는걸 파악했고 FetchJoin으로 문제 해결
학사일정 조회시 DB를 통한 조회로 조회 시간이 오래걸림 -> Redis cache 적용을 통한 조회 속도 개선

### 📎 ETC

K6 테스트를 통해 성능 개선 여부 판단
