### PR TITLE
Fix :: 캐시 매니저 제거 및 grade 타입 변경

### DIFF
--- a/src/main/kotlin/com/seugi/api/domain/schedule/domain/mapper/ScheduleMapper.kt
+++ b/src/main/kotlin/com/seugi/api/domain/schedule/domain/mapper/ScheduleMapper.kt
@@ -17,7 +17,7 @@ class ScheduleMapper : Mapper<Schedule, ScheduleEntity> {
             date = entity.date,
             eventName = entity.eventName,
             eventContent = entity.eventContent,
-            grade = entity.grade
+            grade = entity.grade.toList()
         )
     }
 
@@ -27,7 +27,7 @@ class ScheduleMapper : Mapper<Schedule, ScheduleEntity> {
             date = domain.date!!,
             eventName = domain.eventName ?: "",
             eventContent = domain.eventContent ?: "",
-            grade = domain.grade ?: emptySet()
+            grade = domain.grade?.toSet() ?: emptySet()
         )
     }
 
@@ -47,7 +47,7 @@ class ScheduleMapper : Mapper<Schedule, ScheduleEntity> {
                 date = SchoolDateConvertor.dateFormat(scheduleRow.aaYmd),
                 eventName = scheduleRow.eventNm,
                 eventContent = scheduleRow.eventCntnt,
-                grade = grade
+                grade = grade.toList()
             )
         }
     }

--- a/src/main/kotlin/com/seugi/api/domain/schedule/domain/model/Schedule.kt
+++ b/src/main/kotlin/com/seugi/api/domain/schedule/domain/model/Schedule.kt
@@ -6,5 +6,5 @@ data class Schedule(
     val date: String? = null,
     val eventName: String? = null,
     val eventContent: String? = null,
-    val grade: Set<Int>? = null,
+    val grade: List<Int>? = null,
 )

--- a/src/main/kotlin/com/seugi/api/domain/schedule/service/ScheduleServiceImpl.kt
+++ b/src/main/kotlin/com/seugi/api/domain/schedule/service/ScheduleServiceImpl.kt
@@ -49,7 +49,7 @@ class ScheduleServiceImpl(
     }
 
     @Transactional(readOnly = true)
-    @Cacheable(value = ["schedules"] , key = "#workspaceId", cacheManager = "contentCacheManager")
+    @Cacheable(value = ["schedules"] , key = "#workspaceId")
     override fun getSchoolSchedules(userId: Long, workspaceId: String): List<Schedule> {
         return if (!scheduleRepository.existsByWorkspaceId(workspaceId)) resetSchedule(workspaceId, userId)
         else scheduleRepository.findByWorkspaceId(workspaceId).map { scheduleMapper.toDomain(it) }
@@ -57,7 +57,7 @@ class ScheduleServiceImpl(
     }
 
     @Transactional(readOnly = true)
-    @Cacheable(value = ["schedules"] , key = "#workspaceId", cacheManager = "contentCacheManager")
+    @Cacheable(value = ["schedules"] , key = "#workspaceId")
     override fun getMonthSchoolSchedules(userId: Long, workspaceId: String, month: Int): List<Schedule> {
         return if (!scheduleRepository.existsByWorkspaceId(workspaceId)) {
             resetSchedule(workspaceId, userId).filter { sc ->


### PR DESCRIPTION
캐시 매니저 설정을 제거하고 Schedule의 grade 타입을 Set에서 List로 변경했습니다. 

이를 통해 코드의 일관성을 유지하고 오버헤드를 줄이려는 목적이 있습니다. 하지만 Set, List 직렬화 문제가 발생해 DTO부분만 List로 변경하였습니다.

(간단한 수정사항)