### PR TITLE
Refactor :: Notification N+1 이슈 및 캐싱 적용 #346

### DIFF
--- a/src/main/kotlin/com/seugi/api/domain/notification/domain/NotificationEntity.kt
+++ b/src/main/kotlin/com/seugi/api/domain/notification/domain/NotificationEntity.kt
@@ -31,7 +31,6 @@ class NotificationEntity(
     var content: String,
 
     @ElementCollection
-    @Column(nullable = false)
     val emoji: MutableList<NotificationEmoji> = mutableListOf(),
 
     @Column(nullable = false, updatable = false)

--- a/src/main/kotlin/com/seugi/api/domain/notification/domain/NotificationRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/seugi/api/domain/notification/domain/NotificationRepositoryCustomImpl.kt
@@ -20,9 +20,9 @@ class NotificationRepositoryCustomImpl(
                 notice.workspaceId.eq(workspaceId),
                 notice.deleted.isFalse
             )
-            .orderBy(notice.id.desc())
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())
+            .orderBy(notice.id.desc())
             .fetch().orEmpty().toList()
 
         return jpaQueryFactory
@@ -31,6 +31,7 @@ class NotificationRepositoryCustomImpl(
             .leftJoin(notice.user).fetchJoin()
             .leftJoin(notice.emoji).fetchJoin()
             .where(notice.id.`in`(noticeIdList))
+            .orderBy(notice.id.desc())
             .fetch().orEmpty().toList()
 
     }

--- a/src/main/kotlin/com/seugi/api/domain/notification/domain/NotificationRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/seugi/api/domain/notification/domain/NotificationRepositoryCustomImpl.kt
@@ -20,6 +20,7 @@ class NotificationRepositoryCustomImpl(
                 notice.workspaceId.eq(workspaceId),
                 notice.deleted.isFalse
             )
+            .orderBy(notice.id.desc())
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())
             .fetch().orEmpty().toList()

--- a/src/main/kotlin/com/seugi/api/domain/notification/domain/NotificationRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/seugi/api/domain/notification/domain/NotificationRepositoryCustomImpl.kt
@@ -13,8 +13,8 @@ class NotificationRepositoryCustomImpl(
     override fun findByWorkspaceId(workspaceId: String, pageable: Pageable): List<NotificationEntity> {
         val notice: QNotificationEntity = QNotificationEntity.notificationEntity
 
-        return jpaQueryFactory
-            .select(notice)
+        val noticeIdList = jpaQueryFactory
+            .select(notice.id)
             .from(notice)
             .where(
                 notice.workspaceId.eq(workspaceId),
@@ -24,6 +24,15 @@ class NotificationRepositoryCustomImpl(
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())
             .fetch().orEmpty().toList()
+
+        return jpaQueryFactory
+            .select(notice)
+            .from(notice)
+            .leftJoin(notice.user).fetchJoin()
+            .leftJoin(notice.emoji).fetchJoin()
+            .where(notice.id.`in`(noticeIdList))
+            .fetch().orEmpty().toList()
+
     }
 
 }

--- a/src/main/kotlin/com/seugi/api/domain/notification/presentation/dto/response/NotificationEmojiResponse.kt
+++ b/src/main/kotlin/com/seugi/api/domain/notification/presentation/dto/response/NotificationEmojiResponse.kt
@@ -1,6 +1,6 @@
 package com.seugi.api.domain.notification.presentation.dto.response
 
 data class NotificationEmojiResponse(
-    val emoji: String,
-    val userList: List<Long>,
+    val emoji: String? = null,
+    val userList: List<Long>? = null,
 )

--- a/src/main/kotlin/com/seugi/api/domain/notification/service/NotificationCacheService.kt
+++ b/src/main/kotlin/com/seugi/api/domain/notification/service/NotificationCacheService.kt
@@ -1,0 +1,33 @@
+package com.seugi.api.domain.notification.service
+
+import com.seugi.api.domain.notification.presentation.dto.response.NotificationResponse
+import com.seugi.api.domain.notification.domain.NotificationRepository
+import com.seugi.api.domain.notification.domain.mapper.NotificationMapper
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class NotificationCacheService(
+    private val noticeRepository: NotificationRepository,
+    private val noticeMapper: NotificationMapper
+) {
+
+    @Transactional(readOnly = true)
+    @Cacheable(value = ["notifications"], key = "#workspaceId")
+    fun getNotices(workspaceId: String, pageable: Pageable): List<NotificationResponse> {
+        return noticeRepository.findByWorkspaceId(workspaceId, pageable).map {
+            noticeMapper.transferNoticeResponse(
+                noticeMapper.toDomain(it)
+            )
+        }
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @CacheEvict(value = ["notifications"], key = "#workspaceId")
+    fun deleteCache(workspaceId: String) {}
+
+}

--- a/src/main/kotlin/com/seugi/api/global/config/RedisConfig.kt
+++ b/src/main/kotlin/com/seugi/api/global/config/RedisConfig.kt
@@ -65,9 +65,11 @@ class RedisConfig(
             .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(GenericJackson2JsonRedisSerializer()))
 
         val schedulesCacheConfig = defaultCacheConfig.entryTtl(Duration.ofDays(1))
+        val notificationCacheConfig = defaultCacheConfig.entryTtl(Duration.ofHours(1))
 
         val cacheConfigurations: MutableMap<String, RedisCacheConfiguration> = mutableMapOf()
         cacheConfigurations["schedules"] = schedulesCacheConfig
+        cacheConfigurations["notification"] = notificationCacheConfig
 
         return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory)
             .cacheDefaults(defaultCacheConfig)


### PR DESCRIPTION
# #️⃣ 연관된 이슈

#346 

## 📝 작업 내용

1. Notification 에서 N+1 문제가 발생하는걸 파악했고 이를 해결하였습니다. 
2. 캐싱 적용을 통한 응답 속도를 개선하였습니다.
2.1. 기존 조회 캐싱방식과 다르게 C, U, D 에 대한 반응도 해야해서 로직이 조금 변동되었습니다.

### 📎 ETC
> 기타

학사일정 K6 테스트 결과 응답속도가 97.93% 개선 되었습니다.
N+1, 캐싱 적용 됬으니 Notification도 유의미한 결과가 도출될꺼라 예상합니다.